### PR TITLE
[codex] Refactor SnapSort layout simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ dist-ssr
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/.playwright-mcp/
+/mcp-*.png
+/mcp-*-snapshot.md
 
 # Generated build files
 *.mjs

--- a/assets/snapsort/core/src/container.ts
+++ b/assets/snapsort/core/src/container.ts
@@ -39,6 +39,21 @@ export class ItemContainer extends ItemObject {
     if (!this.#config.direction) {
       this.#config.direction = "column";
     }
+    if (this.#config.animation === undefined) {
+      const defaultAnimation = { duration: 100, timing_function: "ease-out" };
+      this.#config.animation = {
+        reorder: defaultAnimation,
+        drop: defaultAnimation,
+        clickMove: defaultAnimation,
+      };
+    } else if (this.#config.animation) {
+      const defaultAnimation = { duration: 100, timing_function: "ease-out" };
+      this.#config.animation = {
+        reorder: this.#config.animation.reorder ?? defaultAnimation,
+        drop: this.#config.animation.drop ?? defaultAnimation,
+        clickMove: this.#config.animation.clickMove ?? defaultAnimation,
+      };
+    }
     if (!this.#config.name) {
       if (!this.global.data["dragAndDropContainerCounter"]) {
         this.global.data["dragAndDropContainerCounter"] = 0;

--- a/assets/snapsort/core/src/drop_target.ts
+++ b/assets/snapsort/core/src/drop_target.ts
@@ -6,7 +6,13 @@ const TAG_LAYOUT = "drop-layout"; // virtual layout: height bars, layout start l
 const TAG_COLLISIONS = "drop-collisions"; // collision: hitboxes, collision lines, DOM boxes, center points
 const TAG_CANDIDATES = "drop-candidates"; // candidates: result lines, best pick
 const TAG_NEIGHBORS = "drop-neighbors"; // per-candidate prev/next reference points and links
-const TAG_TIEBREAK = "drop-tiebreak"; // distance-tie conflict resolution lines (prev vs next)
+const TAG_SNAPSHOT = "drop-snapshot"; // drag-start snapshot geometry and simulation deltas
+
+const snapshotDumpedForDrag = new WeakSet<ItemObject>();
+
+export function resetDropSnapshotDebugDump(item: ItemObject) {
+  snapshotDumpedForDrag.delete(item);
+}
 
 /** Get layout direction for a container. ItemContainer has a direction getter; default to "column". */
 function getDirection(node: ItemObject): "column" | "row" {
@@ -21,7 +27,457 @@ function euclidean(x1: number, y1: number, x2: number, y2: number): number {
 }
 
 function isSubContainer(item: ItemObject) {
-  return item.itemOrderedList.length > 0;
+  return item.dragSnapshot
+    ? item.dragSnapshotOrderedList.length > 0
+    : item.itemOrderedList.length > 0;
+}
+
+function requireDragSnapshot(item: ItemObject): DomProperty {
+  const snapshot = item.dragSnapshot;
+  if (!snapshot) {
+    const message = `[drop-snapshot] Missing drag snapshot for item ${item.gid}. Drop prediction must run after dragStart captures snapshots.`;
+    console.error(message);
+    throw new Error(message);
+  }
+  return snapshot;
+}
+
+function contentBoxOrigin(prop: DomProperty): { x: number; y: number } {
+  return {
+    x: prop.x + prop.border.left + prop.padding.left,
+    y: prop.y + prop.border.top + prop.padding.top,
+  };
+}
+
+function contentBoxSize(prop: DomProperty): { width: number; height: number } {
+  return {
+    width: Math.max(
+      0,
+      prop.width -
+        prop.border.left -
+        prop.border.right -
+        prop.padding.left -
+        prop.padding.right,
+    ),
+    height: Math.max(
+      0,
+      prop.height -
+        prop.border.top -
+        prop.border.bottom -
+        prop.padding.top -
+        prop.padding.bottom,
+    ),
+  };
+}
+
+function childRelativeOffset(
+  containerProp: DomProperty,
+  childProp: DomProperty,
+): { x: number; y: number } {
+  const origin = contentBoxOrigin(containerProp);
+  return {
+    x: childProp.x - origin.x,
+    y: childProp.y - origin.y,
+  };
+}
+
+function snapshotItems(
+  container: ItemObject,
+  draggedItem: ItemObject,
+): ItemObject[] {
+  return container.dragSnapshotOrderedList.filter(
+    (i) => i !== draggedItem && !i.isGhost,
+  );
+}
+
+function isAfterDraggedInSameLine(
+  container: ItemObject,
+  item: ItemObject,
+  draggedItem: ItemObject,
+  isColumn: boolean,
+): boolean {
+  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
+  const itemIdx = ordered.indexOf(item);
+  const draggedIdx = ordered.indexOf(draggedItem);
+  if (itemIdx === -1 || draggedIdx === -1 || itemIdx <= draggedIdx) {
+    return false;
+  }
+  if (isColumn) return true;
+
+  const containerProp = requireDragSnapshot(container);
+  const itemOffset = childRelativeOffset(containerProp, requireDragSnapshot(item));
+  const draggedOffset = childRelativeOffset(
+    containerProp,
+    requireDragSnapshot(draggedItem),
+  );
+  return Math.abs(itemOffset.y - draggedOffset.y) <= 1;
+}
+
+function draggedGapSpan(
+  container: ItemObject,
+  draggedItem: ItemObject,
+  isColumn: boolean,
+): number {
+  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
+  const draggedIdx = ordered.indexOf(draggedItem);
+  if (draggedIdx === -1) return 0;
+
+  const containerProp = requireDragSnapshot(container);
+  const draggedProp = requireDragSnapshot(draggedItem);
+  const draggedOffset = childRelativeOffset(containerProp, draggedProp);
+  const next = ordered[draggedIdx + 1];
+
+  if (next) {
+    const nextOffset = childRelativeOffset(containerProp, requireDragSnapshot(next));
+    const sameLine = isColumn || Math.abs(nextOffset.y - draggedOffset.y) <= 1;
+    if (sameLine) {
+      const current = isColumn ? draggedOffset.y : draggedOffset.x;
+      const nextStart = isColumn ? nextOffset.y : nextOffset.x;
+      const span = nextStart - current;
+      if (span > 0) return span;
+    }
+  }
+
+  return isColumn ? draggedProp.height : draggedProp.width;
+}
+
+function closeDraggedGapPosition(
+  container: ItemObject,
+  item: ItemObject,
+  measuredPosition: { x: number; y: number },
+  draggedItem: ItemObject,
+  isColumn: boolean,
+): { x: number; y: number } {
+  if (item.locked) return measuredPosition;
+  if (!isAfterDraggedInSameLine(container, item, draggedItem, isColumn)) {
+    return measuredPosition;
+  }
+
+  const span = draggedGapSpan(container, draggedItem, isColumn);
+  return isColumn
+    ? { x: measuredPosition.x, y: measuredPosition.y - span }
+    : { x: measuredPosition.x - span, y: measuredPosition.y };
+}
+
+function gapAfter(
+  container: ItemObject,
+  item: ItemObject,
+  draggedItem: ItemObject,
+  isColumn: boolean,
+): number {
+  const items = snapshotItems(container, draggedItem);
+  const idx = items.indexOf(item);
+  if (idx === -1 || idx >= items.length - 1) return 0;
+
+  const containerProp = requireDragSnapshot(container);
+  const itemProp = requireDragSnapshot(item);
+  const nextProp = requireDragSnapshot(items[idx + 1]);
+  const itemOffset = childRelativeOffset(containerProp, itemProp);
+  const nextOffset = childRelativeOffset(containerProp, nextProp);
+
+  if (!isColumn && Math.abs(itemOffset.y - nextOffset.y) > 1) return 0;
+
+  const itemEnd = isColumn
+    ? itemOffset.y + itemProp.height
+    : itemOffset.x + itemProp.width;
+  const nextStart = isColumn ? nextOffset.y : nextOffset.x;
+  return Math.max(0, nextStart - itemEnd);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function sameSnapshotRow(
+  containerProp: DomProperty,
+  a: ItemObject,
+  b: ItemObject,
+): boolean {
+  const aOffset = childRelativeOffset(containerProp, requireDragSnapshot(a));
+  const bOffset = childRelativeOffset(containerProp, requireDragSnapshot(b));
+  return Math.abs(aOffset.y - bOffset.y) <= 1;
+}
+
+function inferRowLayoutMetrics(container: ItemObject): {
+  rowStartX: number;
+  rowStartY: number;
+  columnGap: number;
+  rowGap: number;
+} {
+  const containerProp = requireDragSnapshot(container);
+  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
+  if (ordered.length === 0) {
+    return { rowStartX: 0, rowStartY: 0, columnGap: 0, rowGap: 0 };
+  }
+
+  const firstOffset = childRelativeOffset(
+    containerProp,
+    requireDragSnapshot(ordered[0]),
+  );
+  const columnGaps: number[] = [];
+  const rows: Array<{ y: number; height: number }> = [];
+  let currentRow: { y: number; height: number } | null = null;
+
+  for (let i = 0; i < ordered.length; i++) {
+    const item = ordered[i];
+    const prop = requireDragSnapshot(item);
+    const offset = childRelativeOffset(containerProp, prop);
+    if (!currentRow || Math.abs(offset.y - currentRow.y) > 1) {
+      currentRow = { y: offset.y, height: prop.height };
+      rows.push(currentRow);
+    } else {
+      currentRow.height = Math.max(currentRow.height, prop.height);
+    }
+
+    const next = ordered[i + 1];
+    if (next && sameSnapshotRow(containerProp, item, next)) {
+      const nextOffset = childRelativeOffset(
+        containerProp,
+        requireDragSnapshot(next),
+      );
+      const gap = nextOffset.x - (offset.x + prop.width);
+      if (gap >= 0) columnGaps.push(gap);
+    }
+  }
+
+  const rowGaps: number[] = [];
+  for (let i = 0; i < rows.length - 1; i++) {
+    const gap = rows[i + 1].y - (rows[i].y + rows[i].height);
+    if (gap >= 0) rowGaps.push(gap);
+  }
+
+  return {
+    rowStartX: firstOffset.x,
+    rowStartY: firstOffset.y,
+    columnGap: median(columnGaps),
+    rowGap: median(rowGaps),
+  };
+}
+
+function rowLayoutPositions(
+  container: ItemObject,
+  draggedItem: ItemObject,
+  startX: number,
+  startY: number,
+  ghost?: { index: number; width: number; height: number },
+): {
+  itemPositions: Map<ItemObject, { x: number; y: number }>;
+  ghostPosition: { x: number; y: number } | null;
+} {
+  const containerProp = requireDragSnapshot(container);
+  const contentSize = contentBoxSize(containerProp);
+  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
+  const items = ordered.filter((i) => i !== draggedItem);
+  const metrics = inferRowLayoutMetrics(container);
+  const entries: Array<
+    | { kind: "item"; item: ItemObject; width: number; height: number }
+    | { kind: "ghost"; width: number; height: number }
+  > = items.map((item) => {
+    const prop = requireDragSnapshot(item);
+    return { kind: "item", item, width: prop.width, height: prop.height };
+  });
+
+  if (ghost) {
+    entries.splice(Math.max(0, Math.min(ghost.index, entries.length)), 0, {
+      kind: "ghost",
+      width: ghost.width,
+      height: ghost.height,
+    });
+  }
+
+  const itemPositions = new Map<ItemObject, { x: number; y: number }>();
+  let ghostPosition: { x: number; y: number } | null = null;
+  const rowStartX = startX + metrics.rowStartX;
+  const maxX = startX + contentSize.width;
+  let cursorX = rowStartX;
+  let cursorY = startY + metrics.rowStartY;
+  let rowHeight = 0;
+
+  for (const entry of entries) {
+    if (
+      cursorX > rowStartX + 0.5 &&
+      cursorX + entry.width > maxX + 0.5
+    ) {
+      cursorX = rowStartX;
+      cursorY += rowHeight + metrics.rowGap;
+      rowHeight = 0;
+    }
+
+    let position = { x: cursorX, y: cursorY };
+    if (entry.kind === "item" && entry.item.locked) {
+      const prop = requireDragSnapshot(entry.item);
+      const rel = childRelativeOffset(containerProp, prop);
+      position = { x: startX + rel.x, y: startY + rel.y };
+      cursorX = position.x;
+      cursorY = position.y;
+    }
+
+    if (entry.kind === "ghost") {
+      ghostPosition = position;
+    } else {
+      itemPositions.set(entry.item, position);
+    }
+
+    cursorX += entry.width + metrics.columnGap;
+    rowHeight = Math.max(rowHeight, entry.height);
+  }
+
+  return { itemPositions, ghostPosition };
+}
+
+function containerContentRect(container: ItemObject) {
+  const prop = requireDragSnapshot(container);
+  const origin = contentBoxOrigin(prop);
+  const size = contentBoxSize(prop);
+  return { ...origin, ...size };
+}
+
+function containsPoint(
+  rect: { x: number; y: number; width: number; height: number },
+  x: number,
+  y: number,
+): boolean {
+  return (
+    x >= rect.x &&
+    x <= rect.x + rect.width &&
+    y >= rect.y &&
+    y <= rect.y + rect.height
+  );
+}
+
+function distanceToNearestContentEdge(
+  rect: { x: number; y: number; width: number; height: number },
+  x: number,
+  y: number,
+): number {
+  if (containsPoint(rect, x, y)) {
+    return Math.min(
+      Math.abs(x - rect.x),
+      Math.abs(rect.x + rect.width - x),
+      Math.abs(y - rect.y),
+      Math.abs(rect.y + rect.height - y),
+    );
+  }
+  const clampedX = Math.max(rect.x, Math.min(x, rect.x + rect.width));
+  const clampedY = Math.max(rect.y, Math.min(y, rect.y + rect.height));
+  return euclidean(x, y, clampedX, clampedY);
+}
+
+function chooseByContentBox(
+  a: DropCandidate,
+  b: DropCandidate,
+  dragCenterX: number,
+  dragCenterY: number,
+): DropCandidate {
+  const aRect = containerContentRect(a.container);
+  const bRect = containerContentRect(b.container);
+  const aContains = containsPoint(aRect, dragCenterX, dragCenterY);
+  const bContains = containsPoint(bRect, dragCenterX, dragCenterY);
+  if (aContains !== bContains) return aContains ? a : b;
+
+  const aEdge = distanceToNearestContentEdge(aRect, dragCenterX, dragCenterY);
+  const bEdge = distanceToNearestContentEdge(bRect, dragCenterX, dragCenterY);
+  if (Math.abs(aEdge - bEdge) > 0.5) return aEdge < bEdge ? a : b;
+  return a.distance <= b.distance ? a : b;
+}
+
+function drawSnapshotDebug(
+  container: ItemObject,
+  item: ItemObject,
+  measuredPosition: { x: number; y: number },
+  simulatedPosition: { x: number; y: number },
+) {
+  const prop = requireDragSnapshot(item);
+  const dx = simulatedPosition.x - measuredPosition.x;
+  const dy = simulatedPosition.y - measuredPosition.y;
+
+  item.addDebugRect(
+    measuredPosition.x,
+    measuredPosition.y,
+    prop.width,
+    prop.height,
+    "rgba(14, 165, 233, 0.45)",
+    true,
+    `drop-snapshot-box-${container.gid}-${item.gid}`,
+    false,
+    1,
+    TAG_SNAPSHOT,
+  );
+  item.addDebugLine(
+    simulatedPosition.x,
+    simulatedPosition.y,
+    measuredPosition.x,
+    measuredPosition.y,
+    "rgba(244, 63, 94, 0.75)",
+    true,
+    `drop-snapshot-delta-${container.gid}-${item.gid}`,
+    2,
+    TAG_SNAPSHOT,
+  );
+  item.addDebugText(
+    measuredPosition.x + 2,
+    measuredPosition.y + prop.height + 12,
+    `delta ${Math.round(dx)},${Math.round(dy)}`,
+    "rgba(244, 63, 94, 0.8)",
+    true,
+    `drop-snapshot-delta-label-${container.gid}-${item.gid}`,
+    TAG_SNAPSHOT,
+  );
+}
+
+function drawContainerContentBox(
+  container: ItemObject,
+  origin: { x: number; y: number },
+) {
+  const size = contentBoxSize(requireDragSnapshot(container));
+  container.addDebugRect(
+    origin.x,
+    origin.y,
+    size.width,
+    size.height,
+    "rgba(20, 184, 166, 0.45)",
+    true,
+    `drop-snapshot-content-${container.gid}`,
+    false,
+    2,
+    TAG_SNAPSHOT,
+  );
+}
+
+function dumpSnapshotOnce(item: ItemObject, root: ItemObject) {
+  if (snapshotDumpedForDrag.has(item)) return;
+  snapshotDumpedForDrag.add(item);
+
+  const grouper =
+    typeof console.groupCollapsed === "function"
+      ? console.groupCollapsed.bind(console)
+      : console.log.bind(console);
+  const ender =
+    typeof console.groupEnd === "function"
+      ? console.groupEnd.bind(console)
+      : () => {};
+
+  const dumpNode = (node: ItemObject, depth = 0) => {
+    const prop = requireDragSnapshot(node);
+    const origin = contentBoxOrigin(prop);
+    const indent = "  ".repeat(depth);
+    console.log(
+      `${indent}${node.gid} contentOrigin=(${Math.round(origin.x)},${Math.round(origin.y)}) ` +
+        `padding=${JSON.stringify(prop.padding)} border=${JSON.stringify(prop.border)}`,
+    );
+    for (const child of node.dragSnapshotOrderedList) {
+      dumpNode(child, depth + 1);
+    }
+  };
+
+  grouper(`[drop-snapshot] root=${root.gid} drag=${item.gid}`);
+  dumpNode(root);
+  ender();
 }
 
 /** Toggle to silence the per-candidate ASCII layout trace in the console. */
@@ -49,6 +505,11 @@ function logCandidateSnapshot(args: {
   priority: number;
   dragCenterX: number;
   dragCenterY: number;
+  layoutItems?: Array<{
+    item: ItemObject;
+    measuredPosition: { x: number; y: number };
+    simulatedPosition: { x: number; y: number };
+  }>;
 }) {
   if (!LAYOUT_TRACE) return;
   const r = (n: number) => Math.round(n);
@@ -88,6 +549,9 @@ function logCandidateSnapshot(args: {
   // their actual rendered size — close to what virtualLayoutRecursive simulated).
   let cursorPrimary = args.isColumn ? args.startY : args.startX;
   const lines: string[] = [];
+  const layoutByItem = new Map(
+    args.layoutItems?.map((entry) => [entry.item, entry]),
+  );
   for (let i = 0; i <= args.items.length; i++) {
     if (i === args.insertIdx) {
       lines.push(
@@ -96,7 +560,7 @@ function logCandidateSnapshot(args: {
     }
     if (i >= args.items.length) break;
     const it = args.items[i];
-    const prop = it.getDomProperty("READ_1");
+    const prop = requireDragSnapshot(it);
     const dim = prop ? (args.isColumn ? prop.height : prop.width) : 0;
     const start = cursorPrimary;
     cursorPrimary += dim;
@@ -104,7 +568,19 @@ function logCandidateSnapshot(args: {
       ? `y=[${r(start)}..${r(cursorPrimary)}] h=${r(dim)}`
       : `x=[${r(start)}..${r(cursorPrimary)}] w=${r(dim)}`;
     const tag = isSubContainer(it) ? "▭" : "▪";
-    lines.push(`${indent}   [${i}] ${tag} ${it.gid}  ${range}`);
+    const layout = layoutByItem.get(it);
+    if (layout) {
+      const rel = childRelativeOffset(requireDragSnapshot(args.container), prop);
+      const dx = layout.simulatedPosition.x - layout.measuredPosition.x;
+      const dy = layout.simulatedPosition.y - layout.measuredPosition.y;
+      lines.push(
+        `${indent}   [${i}] ${tag} ${it.gid}  snapshotOffset=(${r(rel.x)},${r(rel.y)}) ` +
+          `sim=(${r(layout.simulatedPosition.x)},${r(layout.simulatedPosition.y)}) ` +
+          `delta=(${r(dx)},${r(dy)})`,
+      );
+    } else {
+      lines.push(`${indent}   [${i}] ${tag} ${it.gid}  ${range}`);
+    }
   }
   for (const ln of lines) console.log(ln);
 
@@ -147,67 +623,37 @@ export function virtualDimensions(
   draggedItem: ItemObject,
 ): VirtualDimensions {
   const isColumn = getDirection(container) === "column";
-  const containerProp = container.getDomProperty("READ_1");
-  const items = container.itemOrderedList.filter(
-    (i) => i !== draggedItem && !i.isGhost,
-  );
+  const containerProp = requireDragSnapshot(container);
+  const items = snapshotItems(container, draggedItem);
+  const rowPositions = isColumn
+    ? null
+    : rowLayoutPositions(container, draggedItem, 0, 0).itemPositions;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = 0;
+  let maxY = 0;
 
-  if (isColumn) {
-    // Column: stack vertically. Width = max child width, height = sum of child heights.
-    let totalHeight = 0;
-    let maxWidth = 0;
-    for (const child of items) {
-      let childW: number, childH: number;
-      if (child.itemOrderedList.length > 0) {
-        const dims = virtualDimensions(child, draggedItem);
-        childW = dims.width;
-        childH = dims.height;
-      } else {
-        const prop = child.getDomProperty("READ_1");
-        childW = prop ? prop.width : 0;
-        childH = prop ? prop.height : 0;
-      }
-      totalHeight += childH;
-      maxWidth = Math.max(maxWidth, childW);
-    }
-    return { width: maxWidth, height: totalHeight };
-  } else {
-    // Row with wrapping: place items left-to-right, wrap when exceeding container width.
-    const containerWidth = containerProp ? containerProp.width : Infinity;
-    let rowCursorX = 0;
-    let rowMaxHeight = 0;
-    let totalHeight = 0;
-    let maxRowWidth = 0;
-
-    for (const child of items) {
-      let childW: number, childH: number;
-      if (child.itemOrderedList.length > 0) {
-        const dims = virtualDimensions(child, draggedItem);
-        childW = dims.width;
-        childH = dims.height;
-      } else {
-        const prop = child.getDomProperty("READ_1");
-        childW = prop ? prop.width : 0;
-        childH = prop ? prop.height : 0;
-      }
-
-      // Wrap to next row if this item doesn't fit
-      if (rowCursorX > 0 && rowCursorX + childW > containerWidth) {
-        totalHeight += rowMaxHeight;
-        maxRowWidth = Math.max(maxRowWidth, rowCursorX);
-        rowCursorX = 0;
-        rowMaxHeight = 0;
-      }
-
-      rowCursorX += childW;
-      rowMaxHeight = Math.max(rowMaxHeight, childH);
-    }
-    // Final row
-    totalHeight += rowMaxHeight;
-    maxRowWidth = Math.max(maxRowWidth, rowCursorX);
-
-    return { width: maxRowWidth, height: totalHeight };
+  for (const child of items) {
+    const prop = requireDragSnapshot(child);
+    const rel = childRelativeOffset(containerProp, prop);
+    const measured = { x: rel.x, y: rel.y };
+    const simulated =
+      rowPositions?.get(child) ??
+      closeDraggedGapPosition(
+        container,
+        child,
+        measured,
+        draggedItem,
+        isColumn,
+      );
+    minX = Math.min(minX, simulated.x);
+    minY = Math.min(minY, simulated.y);
+    maxX = Math.max(maxX, simulated.x + prop.width);
+    maxY = Math.max(maxY, simulated.y + prop.height);
   }
+
+  if (minX === Infinity || minY === Infinity) return { width: 0, height: 0 };
+  return { width: maxX - minX, height: maxY - minY };
 }
 
 /**
@@ -253,20 +699,23 @@ export function virtualLayoutRecursive(
   dragCenterY: number,
 ): { candidates: DropCandidate[]; endX: number; endY: number } {
   const isColumn = getDirection(container) === "column";
-  const containerProp = container.getDomProperty("READ_1");
-  const containerWidth = containerProp ? containerProp.width : Infinity;
-
-  const items = container.itemOrderedList.filter(
-    (i) => i !== draggedItem && !i.isGhost,
-  );
-
-  // console.debug(`[virtual-layout] container=${container.gid} dir=${isColumn ? "col" : "row"} start=(${Math.round(startX)},${Math.round(startY)}) items=${items.length}`);
+  const containerProp = requireDragSnapshot(container);
+  const contentSize = contentBoxSize(containerProp);
+  const containerWidth = contentSize.width;
+  const items = snapshotItems(container, draggedItem);
+  const rowPositions = isColumn
+    ? null
+    : rowLayoutPositions(container, draggedItem, startX, startY).itemPositions;
 
   const thisCandidates: DropCandidate[] = [];
   const childCandidates: DropCandidate[] = [];
+  const layoutItems: Array<{
+    item: ItemObject;
+    measuredPosition: { x: number; y: number };
+    simulatedPosition: { x: number; y: number };
+  }> = [];
 
-  // TODO: take padding into account so distance can be used as tie breakers
-  // in container conflicts.
+  drawContainerContentBox(container, { x: startX, y: startY });
 
   // Clear stale ghost candidate debug rects
   for (let j = 0; j < items.length; j++) {
@@ -274,153 +723,130 @@ export function virtualLayoutRecursive(
     container.clearDebugMarker(`vlayout-ghost-after-${container.gid}-${j}`);
   }
 
-  if (isColumn) {
-    // Column layout: single cursor moving down
-    let cursorY = startY;
+  for (let j = 0; j < items.length; j++) {
+    const item = items[j];
+    const isColliding = collidingSet.has(item);
+    const prop = requireDragSnapshot(item);
+    const isContainer = isSubContainer(item);
+    const rel = childRelativeOffset(containerProp, prop);
+    const measuredPosition = { x: startX + rel.x, y: startY + rel.y };
+    const simulatedPosition =
+      rowPositions?.get(item) ??
+      closeDraggedGapPosition(
+        container,
+        item,
+        measuredPosition,
+        draggedItem,
+        isColumn,
+      );
+    layoutItems.push({ item, measuredPosition, simulatedPosition });
+    drawSnapshotDebug(container, item, measuredPosition, simulatedPosition);
 
-    for (let j = 0; j < items.length; j++) {
-      const item = items[j];
-      const isColliding = collidingSet.has(item);
-      const prop = item.getDomProperty("READ_1");
-      const isContainer = isSubContainer(item);
+    const newNode: VirtualNode = {
+      containerGID: container.gid,
+      item,
+      prop,
+      position: simulatedPosition,
+      previous: node,
+      next: null,
+    };
+    const prevNode = isContainer ? node : node.previous;
+    if (!isContainer) {
+      node.next = newNode;
+      node = newNode;
+    }
 
-      const newNode = {
-        containerGID: container.gid,
-        item: item,
-        prop: prop,
-        position: {
-          x: startX,
-          y: cursorY,
-        },
-        previous: node,
-        next: null,
+    if (isColliding && !item.locked) {
+      const rowGhostPosition = isColumn
+        ? null
+        : rowLayoutPositions(container, draggedItem, startX, startY, {
+            index: j,
+            width: dragGhostW,
+            height: dragGhostH,
+          }).ghostPosition;
+      const ghostX = rowGhostPosition?.x ?? simulatedPosition.x;
+      const ghostY = rowGhostPosition?.y ?? simulatedPosition.y;
+      const gcx = ghostX + dragGhostW / 2;
+      const gcy = ghostY + dragGhostH / 2;
+      const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
+      const nextPosition = isColumn
+        ? { x: ghostX, y: ghostY + dragGhostH }
+        : { x: ghostX + dragGhostW, y: ghostY };
+
+      thisCandidates.push({
+        container,
+        index: j,
+        ghostCenterX: gcx,
+        ghostCenterY: gcy,
+        distance: dist,
+        priority: 0,
+        virtualNode: isContainer ? newNode : node,
+        prevPosition: prevNode && prevNode.position ? prevNode.position : null,
+        nextPosition,
+      });
+      logCandidateSnapshot({
+        container,
+        items,
+        insertIdx: j,
+        isColumn,
+        startX,
+        startY,
+        containerWidth,
+        ghostCenterX: gcx,
+        ghostCenterY: gcy,
+        ghostW: dragGhostW,
+        ghostH: dragGhostH,
+        distance: dist,
+        priority: 0,
+        dragCenterX,
+        dragCenterY,
+        layoutItems,
+      });
+      container.addDebugRect(
+        ghostX,
+        ghostY,
+        isColumn ? containerWidth : dragGhostW,
+        isColumn ? dragGhostH : dragGhostH,
+        "rgba(250, 204, 21, 0.15)",
+        true,
+        `vlayout-ghost-before-${container.gid}-${j}`,
+        true,
+        1,
+        TAG_LAYOUT,
+      );
+    }
+
+    if (isContainer) {
+      const childOrigin = {
+        x: simulatedPosition.x + prop.border.left + prop.padding.left,
+        y: simulatedPosition.y + prop.border.top + prop.padding.top,
       };
-      // Skip nodes for containers, we only link leaf nodes
-      if (!isContainer) {
-        node.next = newNode;
-        node = newNode;
+      const sub = virtualLayoutRecursive(
+        item,
+        node,
+        childOrigin.x,
+        childOrigin.y,
+        draggedItem,
+        dragGhostW,
+        dragGhostH,
+        collidingSet,
+        dragCenterX,
+        dragCenterY,
+      );
+      childCandidates.push(...sub.candidates);
+      while (node.next) {
+        node = node.next;
       }
+    }
 
-      // If this item is colliding with the drag item,
-      // calculate a hypothetical layout where the ghost is added to the previous index.
-      // Skip containers and items that are locked
-      if (isColliding && !item.locked) {
-        //
-        // BEFORE-case: insert ghost at index j (above current item).
-        //
-        //   x = startX                  x = startX + containerWidth
-        //   ├────────────────────────────┤
-        //   │  item[j-1]  (node.previous)│  ← prevPosition = node.previous.position
-        //   ├────────────────────────────┤  ← y = cursorY              ┐
-        //   │  GHOST  (insert idx = j)   │     center = (gcx, gcy)     │ dragGhostH
-        //   ├────────────────────────────┤  ← y = cursorY + dragGhostH ┘  (nextPosition.y)
-        //   │  item[j]  (current/node)   │     ← nextPosition aligns to top of current item
-        //   └────────────────────────────┘
-        //
-        // The ghost's center sits halfway down the inserted slot. prev/next
-        // positions are the snap targets used later for the drop indicator.
-        //
-        const gcx = startX + dragGhostW / 2;
-        const gcy = cursorY + dragGhostH / 2;
-        const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
-
-        // let prevPosition = null;
-        // if (node.previous && node.previous.prop) {
-        //   prevPosition = {
-        //     x: startX,
-        //     y: cursorY, // - node.previous!.prop!.height / 2,
-        //   };
-        // }
-        const nextPosition = {
-          x: startX,
-          y: cursorY + dragGhostH,
-        };
-
-        const prevNode = isContainer ? node : node.previous;
-
-        thisCandidates.push({
-          container,
-          index: j,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          distance: dist,
-          priority: 0,
-          virtualNode: isContainer ? newNode : node,
-          prevPosition:
-            prevNode && prevNode.position ? prevNode.position : null,
-          nextPosition: nextPosition,
-        });
-        logCandidateSnapshot({
-          container,
-          items,
-          insertIdx: j,
-          isColumn: true,
-          startX,
-          startY,
-          containerWidth,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          ghostW: dragGhostW,
-          ghostH: dragGhostH,
-          distance: dist,
-          priority: 0,
-          // prevCenter,
-          // nextCenter,
-          // prevContainer,
-          // nextContainer,
-          dragCenterX,
-          dragCenterY,
-        });
-        container.addDebugRect(
-          startX,
-          cursorY,
-          containerWidth,
-          dragGhostH,
-          "rgba(250, 204, 21, 0.15)",
-          true,
-          `vlayout-ghost-before-${container.gid}-${j}`,
-          true,
-          1,
-          TAG_LAYOUT,
-        );
-      }
-
-      const itemStartY = cursorY;
-      let childH: number;
-
-      // If the item is a container, recursively build the virtual layout
-      if (isContainer) {
-        const sub = virtualLayoutRecursive(
-          item,
-          node,
-          startX,
-          cursorY,
-          draggedItem,
-          dragGhostW,
-          dragGhostH,
-          collidingSet,
-          dragCenterX,
-          dragCenterY,
-        );
-        childCandidates.push(...sub.candidates);
-        childH = sub.endY - cursorY;
-
-        while (node.next) {
-          node = node.next;
-        }
-      } else {
-        childH = prop ? prop.height : 0;
-      }
-      cursorY += childH;
-
-      // Debug: vertical bar for this item's height
-      const rootProp = container.rootContainer?.getDomProperty("READ_1");
-      const barX = (rootProp ? rootProp.x : startX) - 6 + container.depth * 10;
+    const barX = startX - 6 + container.depth * 10;
+    const barY = startY - 6 + container.depth * 10;
+    if (isColumn) {
       item.addDebugLine(
         barX,
-        itemStartY,
+        simulatedPosition.y,
         barX,
-        cursorY,
+        simulatedPosition.y + prop.height,
         "rgba(180, 100, 255, 0.7)",
         true,
         `vlayout-height-${item.gid}`,
@@ -429,251 +855,18 @@ export function virtualLayoutRecursive(
       );
       item.addDebugText(
         barX - 30,
-        itemStartY + childH / 2 + 4,
-        `${Math.round(childH)}`,
+        simulatedPosition.y + prop.height / 2 + 4,
+        `${Math.round(prop.height)}`,
         "rgba(180, 100, 255, 0.7)",
         true,
         `vlayout-height-label-${item.gid}`,
         TAG_LAYOUT,
       );
-
-      // Calculate a hypothetical layout where the ghost is added to the next index
-      if (isColliding && !item.locked) {
-        //
-        // AFTER-case: insert ghost at index j+1 (below current item).
-        //
-        // At this point cursorY has advanced past item[j], so it points at
-        // the bottom edge of the current item (= top edge of the new ghost).
-        //
-        //   x = startX                  x = startX + containerWidth
-        //   ├────────────────────────────┤
-        //   │  item[j-1]  (node.previous)│
-        //   ├────────────────────────────┤
-        //   │  item[j]  (current/node)   │     ← prevPosition.y sits at this item's vertical
-        //   │                            │       midline: cursorY − prev.height/2
-        //   ├────────────────────────────┤  ← y = cursorY              ┐
-        //   │  GHOST (insert idx = j+1)  │     center = (gcx, gcy)     │ dragGhostH
-        //   ├────────────────────────────┤  ← y = cursorY + dragGhostH ┘  (nextPosition.y)
-        //   │  item[j+1]  (would-be next)│     ← nextPosition aligns to top of next item
-        //   └────────────────────────────┘
-        //
-        // NOTE: `node` was reassigned to the just-placed item earlier in the
-        // loop, so `node.previous` here refers to the item ABOVE the current
-        // one (item[j-1]) — see prevPosition calculation below.
-        //
-        const gcx = startX + dragGhostW / 2;
-        const gcy = cursorY + dragGhostH / 2;
-        const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
-
-        const prevPosition = {
-          x: startX,
-          y: itemStartY,
-        };
-        const nextPosition = {
-          x: startX,
-          y: cursorY + dragGhostH,
-        };
-
-        thisCandidates.push({
-          container,
-          index: j + 1,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          distance: dist,
-          priority: 0,
-          virtualNode: item.itemOrderedList.length == 0 ? node : newNode,
-          prevPosition: prevPosition,
-          nextPosition: nextPosition,
-        });
-        logCandidateSnapshot({
-          container,
-          items,
-          insertIdx: j + 1,
-          isColumn: true,
-          startX,
-          startY,
-          containerWidth,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          ghostW: dragGhostW,
-          ghostH: dragGhostH,
-          distance: dist,
-          priority: 0,
-          dragCenterX,
-          dragCenterY,
-        });
-        container.addDebugRect(
-          startX,
-          cursorY,
-          containerWidth,
-          dragGhostH,
-          "rgba(250, 204, 21, 0.15)",
-          true,
-          `vlayout-ghost-after-${container.gid}-${j}`,
-          true,
-          1,
-          TAG_LAYOUT,
-        );
-      }
-    }
-
-    let candidates: DropCandidate[] = [];
-    if (container.noDrop) {
-      candidates = childCandidates;
     } else {
-      candidates = childCandidates.concat(thisCandidates);
-    }
-
-    return { candidates, endX: startX + containerWidth, endY: cursorY };
-  } else {
-    // Row layout with wrapping
-    let cursorX = startX;
-    let cursorY = startY;
-    let rowMaxH = 0;
-
-    for (let j = 0; j < items.length; j++) {
-      const item = items[j];
-      const isColliding = collidingSet.has(item);
-      const prop = item.getDomProperty("READ_1");
-      const isContainer = isSubContainer(item);
-
-      // Get child dimensions FIRST so the wrap-check can run before placement.
-      let childW: number, childH: number;
-      if (item.itemOrderedList.length > 0) {
-        const dims = virtualDimensions(item, draggedItem);
-        childW = dims.width;
-        childH = dims.height;
-      } else {
-        childW = prop ? prop.width : 0;
-        childH = prop ? prop.height : 0;
-      }
-
-      // Wrap check: if this item doesn't fit on the current row, advance to
-      // the next one. Done before newNode construction so position reflects
-      // the true post-wrap origin.
-      if (cursorX > startX && cursorX + childW > startX + containerWidth) {
-        cursorY += rowMaxH;
-        cursorX = startX;
-        rowMaxH = 0;
-      }
-
-      // Build the virtual node. As in the column branch, only LEAVES are
-      // linked into the chain — container nodes are constructed for use as
-      // candidate `virtualNode` payloads but skipped from the prev/next walk.
-      const newNode = {
-        containerGID: container.gid,
-        item: item,
-        prop: prop,
-        position: { x: cursorX, y: cursorY },
-        previous: node,
-        next: null,
-      };
-      if (!isContainer) {
-        node.next = newNode;
-        node = newNode;
-      }
-
-      // BEFORE-case: insert ghost to the LEFT of current item (idx = j).
-      //
-      //   ┌──── current row ─────────────────────────────────────┐
-      //   │ item[j-1] │ GHOST(idx=j) │ item[j]   │ ...           │
-      //   └───────────┴──────────────┴───────────┴───────────────┘
-      //               ↑ (ghostX, ghostY)
-      //
-      // The ghost may itself wrap onto a fresh row if it doesn't fit in the
-      // remaining horizontal space. prevPosition snaps to the previous leaf's
-      // saved top-left; nextPosition snaps to the right edge of the ghost
-      // (= where the would-be-next item would begin).
-      if (isColliding) {
-        let ghostX = cursorX;
-        let ghostY = cursorY;
-        if (ghostX > startX && ghostX + dragGhostW > startX + containerWidth) {
-          ghostY += rowMaxH;
-          ghostX = startX;
-        }
-        const gcx = ghostX + dragGhostW / 2;
-        const gcy = ghostY + dragGhostH / 2;
-        const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
-
-        const nextPosition = { x: ghostX + dragGhostW, y: ghostY };
-
-        const prevNode = isContainer ? node : node.previous;
-
-        thisCandidates.push({
-          container,
-          index: j,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          distance: dist,
-          priority: 0,
-          virtualNode: isContainer ? newNode : node,
-          prevPosition:
-            prevNode && prevNode.position ? prevNode.position : null,
-          nextPosition: nextPosition,
-        });
-        logCandidateSnapshot({
-          container,
-          items,
-          insertIdx: j,
-          isColumn: false,
-          startX,
-          startY,
-          containerWidth,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          ghostW: dragGhostW,
-          ghostH: dragGhostH,
-          distance: dist,
-          priority: 0,
-          dragCenterX,
-          dragCenterY,
-        });
-        container.addDebugRect(
-          ghostX,
-          ghostY,
-          dragGhostW,
-          dragGhostH,
-          "rgba(250, 204, 21, 0.15)",
-          true,
-          `vlayout-ghost-before-${container.gid}-${j}`,
-          true,
-          1,
-          TAG_LAYOUT,
-        );
-      }
-
-      // Place item and advance
-      const itemStartX = cursorX;
-      if (isContainer) {
-        const sub = virtualLayoutRecursive(
-          item,
-          node,
-          cursorX,
-          cursorY,
-          draggedItem,
-          dragGhostW,
-          dragGhostH,
-          collidingSet,
-          dragCenterX,
-          dragCenterY,
-        );
-        childCandidates.push(...sub.candidates);
-        // Walk past whatever leaves the recursion appended so the outer
-        // cursor reflects the true tail of the chain (mirrors column).
-        while (node.next) {
-          node = node.next;
-        }
-      }
-      cursorX += childW;
-      rowMaxH = Math.max(rowMaxH, childH);
-
-      // Debug: horizontal bar for this item's width
-      const rootProp = container.rootContainer?.getDomProperty("READ_1");
-      const barY = (rootProp ? rootProp.y : startY) - 6 + container.depth * 10;
       item.addDebugLine(
-        itemStartX,
+        simulatedPosition.x,
         barY,
-        cursorX,
+        simulatedPosition.x + prop.width,
         barY,
         "rgba(180, 100, 255, 0.7)",
         true,
@@ -682,92 +875,90 @@ export function virtualLayoutRecursive(
         TAG_LAYOUT,
       );
       item.addDebugText(
-        itemStartX + childW / 2 - 8,
+        simulatedPosition.x + prop.width / 2 - 8,
         barY - 8,
-        `${Math.round(childW)}`,
+        `${Math.round(prop.width)}`,
         "rgba(180, 100, 255, 0.7)",
         true,
         `vlayout-height-label-${item.gid}`,
         TAG_LAYOUT,
       );
-
-      // AFTER-case: insert ghost to the RIGHT of current item (idx = j+1).
-      //
-      //   ┌──── current row ─────────────────────────────────────┐
-      //   │ ... │ item[j] │ GHOST(idx=j+1) │ item[j+1] │ ...     │
-      //   └─────┴─────────┴────────────────┴───────────┴─────────┘
-      //                   ↑ (ghostX, ghostY)
-      //
-      // prevPosition snaps to the just-placed item's top-left; nextPosition
-      // snaps to the right edge of the ghost (where the next item would
-      // begin if it slid over). Both honor the post-wrap ghost row.
-      if (isColliding) {
-        let ghostX = cursorX;
-        let ghostY = cursorY;
-        if (ghostX > startX && ghostX + dragGhostW > startX + containerWidth) {
-          ghostY += rowMaxH;
-          ghostX = startX;
-        }
-        const gcx = ghostX + dragGhostW / 2;
-        const gcy = ghostY + dragGhostH / 2;
-        const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
-
-        const prevPosition = { x: itemStartX, y: cursorY };
-        const nextPosition = { x: ghostX + dragGhostW, y: ghostY };
-
-        thisCandidates.push({
-          container,
-          index: j + 1,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          distance: dist,
-          priority: 0,
-          virtualNode: node,
-          prevPosition: prevPosition,
-          nextPosition: nextPosition,
-        });
-        logCandidateSnapshot({
-          container,
-          items,
-          insertIdx: j + 1,
-          isColumn: false,
-          startX,
-          startY,
-          containerWidth,
-          ghostCenterX: gcx,
-          ghostCenterY: gcy,
-          ghostW: dragGhostW,
-          ghostH: dragGhostH,
-          distance: dist,
-          priority: 0,
-          dragCenterX,
-          dragCenterY,
-        });
-        container.addDebugRect(
-          ghostX,
-          ghostY,
-          dragGhostW,
-          dragGhostH,
-          "rgba(250, 204, 21, 0.15)",
-          true,
-          `vlayout-ghost-after-${container.gid}-${j}`,
-          true,
-          1,
-          TAG_LAYOUT,
-        );
-      }
     }
 
-    // Final row height
-    cursorY += rowMaxH;
-    let candidates: DropCandidate[] = [];
-    if (container.noDrop) {
-      candidates = childCandidates;
-    } else {
-      candidates = childCandidates.concat(thisCandidates);
+    if (isColliding && !item.locked) {
+      const gap = gapAfter(container, item, draggedItem, isColumn);
+      const rowGhostPosition = isColumn
+        ? null
+        : rowLayoutPositions(container, draggedItem, startX, startY, {
+            index: j + 1,
+            width: dragGhostW,
+            height: dragGhostH,
+          }).ghostPosition;
+      const ghostX =
+        rowGhostPosition?.x ??
+        (isColumn ? simulatedPosition.x : simulatedPosition.x + prop.width + gap);
+      const ghostY =
+        rowGhostPosition?.y ??
+        (isColumn ? simulatedPosition.y + prop.height + gap : simulatedPosition.y);
+      const gcx = ghostX + dragGhostW / 2;
+      const gcy = ghostY + dragGhostH / 2;
+      const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
+      const nextPosition = isColumn
+        ? { x: ghostX, y: ghostY + dragGhostH }
+        : { x: ghostX + dragGhostW, y: ghostY };
+
+      thisCandidates.push({
+        container,
+        index: j + 1,
+        ghostCenterX: gcx,
+        ghostCenterY: gcy,
+        distance: dist,
+        priority: 0,
+        virtualNode: isContainer ? newNode : node,
+        prevPosition: simulatedPosition,
+        nextPosition,
+      });
+      logCandidateSnapshot({
+        container,
+        items,
+        insertIdx: j + 1,
+        isColumn,
+        startX,
+        startY,
+        containerWidth,
+        ghostCenterX: gcx,
+        ghostCenterY: gcy,
+        ghostW: dragGhostW,
+        ghostH: dragGhostH,
+        distance: dist,
+        priority: 0,
+        dragCenterX,
+        dragCenterY,
+        layoutItems,
+      });
+      container.addDebugRect(
+        ghostX,
+        ghostY,
+        isColumn ? containerWidth : dragGhostW,
+        dragGhostH,
+        "rgba(250, 204, 21, 0.15)",
+        true,
+        `vlayout-ghost-after-${container.gid}-${j}`,
+        true,
+        1,
+        TAG_LAYOUT,
+      );
     }
-    return { candidates, endX: cursorX, endY: cursorY };
   }
+
+  const candidates = container.noDrop
+    ? childCandidates
+    : childCandidates.concat(thisCandidates);
+  return {
+    candidates,
+    endX: startX + contentSize.width,
+    endY: startY + contentSize.height,
+  };
 }
 
 /**
@@ -793,14 +984,14 @@ export function determineDropTarget(
 
   let best: DropCandidate | null = null;
 
-  const rootProp = root.getDomProperty("READ_1");
-  const dragProp = item.getDomProperty("READ_1");
+  const rootProp = requireDragSnapshot(root);
+  const dragProp = requireDragSnapshot(item);
   const dragGhostW = dragProp.width;
   const dragGhostH = dragProp.height;
   const dragCenterX = item.transform.x + dragProp.width / 2;
   const dragCenterY = item.transform.y + dragProp.height / 2;
-  const layoutX = rootProp ? rootProp.x : 0;
-  const layoutY = rootProp ? rootProp.y : 0;
+  const layoutOrigin = contentBoxOrigin(rootProp);
+  dumpSnapshotOnce(item, root);
 
   // Build a global flat-leaf index so each candidate can carry references
   // to the items immediately before/after its insertion point in DOM order
@@ -829,8 +1020,8 @@ export function determineDropTarget(
   const { candidates: virtualCandidates } = virtualLayoutRecursive(
     root,
     head,
-    layoutX,
-    layoutY,
+    layoutOrigin.x,
+    layoutOrigin.y,
     item,
     dragGhostW,
     dragGhostH,
@@ -840,9 +1031,6 @@ export function determineDropTarget(
   );
   const candidates: DropCandidate[] = [];
   candidates.push(...virtualCandidates);
-
-  console.log(head);
-  console.log(candidates);
 
   // Clear any tie-break overlays from the previous frame so they don't ghost.
   // We allocate a generous slot range — in practice ties are rare, but multiple
@@ -856,182 +1044,17 @@ export function determineDropTarget(
     root.clearDebugMarker(`drop-tiebreak-next-dot-${i}`);
     root.clearDebugMarker(`drop-tiebreak-next-label-${i}`);
   }
-  let tieBreakIdx = 0;
-
-  // const ties: DropCandidate[] = [];
   // Pick best candidate: higher priority wins first, then shorter distance
   for (const c of candidates) {
     if (!best) {
       best = c;
       continue;
     }
-    // If there is a tie, it is likely a "conflicting container" case
     if (
       Math.abs(c.distance - best.distance) <= 1 &&
       c.container.gid != best.container.gid
     ) {
-      console.log("conflict");
-      // let nodeBest = best.virtualNode;
-      const candidateGID: string = c.container.gid;
-      // const bestGID = best.container.gid;
-      // let nodeCandidate = c.virtualNode;
-      // If there is no prevElement, place a prior stub element the same size as the ghost
-      const dropCandidateOfPrev: DropCandidate =
-        c.virtualNode.previous!.containerGID == candidateGID ? c : best;
-      const dropCandidateOfNext: DropCandidate =
-        c.virtualNode.next && c.virtualNode.next.containerGID == candidateGID
-          ? c
-          : best;
-      //   best.nextPosition &&
-      //   best.container.gid == best.virtualNode.next.item.gid
-      //     ? c
-      //     : best;
-      console.log(
-        dropCandidateOfNext.container.gid,
-        dropCandidateOfPrev.container.gid,
-      );
-      // TODO: handle row layout
-      //
-      // Tie-break geometry — two "arms" reach out from the drag center to the
-      // midpoints of the prev and next neighbors. The shorter arm wins.
-      //
-      //                ◐  prev midpoint
-      //                    (c.prevPosition.x,
-      //                     c.prevPosition.y + prev.height/2)
-      //               ╱
-      //              ╱
-      //   arm_prev  ╱   ← length = distanceToPrev
-      //            ╱
-      //           ╱
-      //          ●  drag center (dragCenterX, dragCenterY)
-      //           ╲
-      //            ╲
-      //   arm_next  ╲   ← length = distanceToNext
-      //              ╲
-      //               ╲
-      //                ◑  next midpoint
-      //                    (c.nextPosition.x,
-      //                     c.nextPosition.y + next.height/2)
-      //
-      // Whichever arm is shorter wins; the corresponding candidate becomes
-      // `best`. The debug overlay drawn below renders these two arms in
-      // magenta (prev) and cyan (next), with the winning arm bolded.
-      //
-      let distanceToPrev = dragGhostH;
-      let distanceToNext = dragGhostH;
-      // Midpoints of the prev/next neighbors used for the tie-break comparison.
-      // Captured here so the debug overlay below can render the exact points
-      // the algorithm compared against (rather than re-deriving them).
-      let prevMidX: number | null = null;
-      let prevMidY: number | null = null;
-      let nextMidX: number | null = null;
-      let nextMidY: number | null = null;
-      if (
-        c.prevPosition &&
-        c.virtualNode.previous &&
-        c.virtualNode.previous.prop
-      ) {
-        prevMidX = c.prevPosition.x;
-        prevMidY = c.prevPosition.y + c.virtualNode.previous.prop.height / 2;
-        distanceToPrev = euclidean(
-          prevMidX,
-          prevMidY,
-          dragCenterX,
-          dragCenterY,
-        );
-      }
-      if (c.nextPosition && c.virtualNode.next && c.virtualNode.next.prop) {
-        nextMidX = c.nextPosition.x;
-        nextMidY = c.nextPosition.y + c.virtualNode.next.prop.height / 2;
-        distanceToNext = euclidean(
-          nextMidX,
-          nextMidY,
-          dragCenterX,
-          dragCenterY,
-        );
-      }
-      console.log(distanceToPrev, distanceToNext);
-      const prevWins = distanceToPrev < distanceToNext;
-      best = prevWins ? dropCandidateOfPrev : dropCandidateOfNext;
-      // best = c;
-
-      // --- Debug: tie-break visualization ---
-      // Draw a line from the drag center to each compared midpoint. The
-      // winning side (shorter segment) is rendered bold/saturated; the
-      // losing side is faded so the ranking is obvious at a glance.
-      const slot = tieBreakIdx++ % TIEBREAK_MARKER_SLOTS;
-      const r = (n: number) => Math.round(n);
-      // Magenta = prev side, cyan = next side. Winner full alpha, loser dim.
-      const prevColor = prevWins
-        ? "rgba(236, 72, 153, 0.95)"
-        : "rgba(236, 72, 153, 0.3)";
-      const nextColor = !prevWins
-        ? "rgba(34, 211, 238, 0.95)"
-        : "rgba(34, 211, 238, 0.3)";
-
-      if (prevMidX !== null && prevMidY !== null) {
-        root.addDebugLine(
-          dragCenterX,
-          dragCenterY,
-          prevMidX,
-          prevMidY,
-          prevColor,
-          true,
-          `drop-tiebreak-prev-line-${slot}`,
-          prevWins ? 3 : 1,
-          TAG_TIEBREAK,
-        );
-        root.addDebugCircle(
-          prevMidX,
-          prevMidY,
-          prevWins ? 7 : 4,
-          prevColor,
-          true,
-          `drop-tiebreak-prev-dot-${slot}`,
-          TAG_TIEBREAK,
-        );
-        root.addDebugText(
-          (dragCenterX + prevMidX) / 2 + 6,
-          (dragCenterY + prevMidY) / 2,
-          `${prevWins ? "✔ " : ""}prev d=${r(distanceToPrev)}`,
-          prevColor,
-          true,
-          `drop-tiebreak-prev-label-${slot}`,
-          TAG_TIEBREAK,
-        );
-      }
-
-      if (nextMidX !== null && nextMidY !== null) {
-        root.addDebugLine(
-          dragCenterX,
-          dragCenterY,
-          nextMidX,
-          nextMidY,
-          nextColor,
-          true,
-          `drop-tiebreak-next-line-${slot}`,
-          !prevWins ? 3 : 1,
-          TAG_TIEBREAK,
-        );
-        root.addDebugCircle(
-          nextMidX,
-          nextMidY,
-          !prevWins ? 7 : 4,
-          nextColor,
-          true,
-          `drop-tiebreak-next-dot-${slot}`,
-          TAG_TIEBREAK,
-        );
-        root.addDebugText(
-          (dragCenterX + nextMidX) / 2 + 6,
-          (dragCenterY + nextMidY) / 2 + 12,
-          `${!prevWins ? "✔ " : ""}next d=${r(distanceToNext)}`,
-          nextColor,
-          true,
-          `drop-tiebreak-next-label-${slot}`,
-          TAG_TIEBREAK,
-        );
-      }
+      best = chooseByContentBox(best, c, dragCenterX, dragCenterY);
     } else if (c.distance < best.distance) {
       best = c;
     }

--- a/assets/snapsort/core/src/drop_target.ts
+++ b/assets/snapsort/core/src/drop_target.ts
@@ -69,6 +69,13 @@ interface FlowPositionResult {
   ghostPosition: { x: number; y: number } | null;
 }
 
+export interface VirtualGhost {
+  container: ItemObject;
+  index: number;
+  width: number;
+  height: number;
+}
+
 type FlowEntry =
   | { kind: "item"; item: ItemObject; width: number; height: number }
   | { kind: "ghost"; width: number; height: number };
@@ -254,15 +261,6 @@ function median(values: number[]): number {
 }
 
 /**
- * Decide whether two snapshot items occupy the same flex line.
- *
- * @param containerProp Frozen DOM property for the parent container.
- * @param a First item to compare.
- * @param b Second item to compare.
- * @param axes Axis mapping for the parent container.
- * @returns True when both items have effectively equal cross-axis starts.
- */
-/**
  * Infer flex line starts and gaps from the frozen DOM snapshot.
  *
  * CSS flexbox can be affected by margins and content size, so replaying
@@ -368,7 +366,7 @@ function flowLayoutPositions(
   draggedItem: ItemObject,
   startX: number,
   startY: number,
-  ghost?: { index: number; width: number; height: number },
+  ghost?: VirtualGhost,
 ): FlowPositionResult {
   const axes = flowAxes(container);
   const containerProp = requireDragSnapshot(container);
@@ -377,11 +375,18 @@ function flowLayoutPositions(
   const items = ordered.filter((i) => i !== draggedItem);
   const metrics = inferFlowLayoutMetrics(container, axes);
   const entries: FlowEntry[] = items.map((item) => {
-    const prop = requireDragSnapshot(item);
-    return { kind: "item", item, width: prop.width, height: prop.height };
+    const dimensions = isSubContainer(item)
+      ? virtualDimensions(item, draggedItem, ghost)
+      : requireDragSnapshot(item);
+    return {
+      kind: "item",
+      item,
+      width: dimensions.width,
+      height: dimensions.height,
+    };
   });
 
-  if (ghost) {
+  if (ghost?.container === container) {
     entries.splice(Math.max(0, Math.min(ghost.index, entries.length)), 0, {
       kind: "ghost",
       width: ghost.width,
@@ -781,12 +786,15 @@ export interface DropCandidate {
  *
  * @param container Container whose children should be simulated.
  * @param draggedItem Item currently being dragged and omitted from layout.
+ * @param ghost Optional ghost insertion whose size should affect ancestor containers.
  * @returns Virtual width and height of the remaining children.
  */
 export function virtualDimensions(
   container: ItemObject,
   draggedItem: ItemObject,
+  ghost?: VirtualGhost,
 ): VirtualDimensions {
+  const axes = flowAxes(container);
   const containerProp = requireDragSnapshot(container);
   const items = snapshotItems(container, draggedItem);
   const flowPositions = flowLayoutPositions(
@@ -794,25 +802,61 @@ export function virtualDimensions(
     draggedItem,
     0,
     0,
-  ).itemPositions;
-  let minX = Infinity;
-  let minY = Infinity;
+    ghost,
+  );
   let maxX = 0;
   let maxY = 0;
 
   for (const child of items) {
-    const prop = requireDragSnapshot(child);
-    const rel = childRelativeOffset(containerProp, prop);
+    const dimensions = isSubContainer(child)
+      ? virtualDimensions(child, draggedItem, ghost)
+      : requireDragSnapshot(child);
+    const rel = childRelativeOffset(containerProp, requireDragSnapshot(child));
     const measured = { x: rel.x, y: rel.y };
-    const simulated = flowPositions.get(child) ?? measured;
-    minX = Math.min(minX, simulated.x);
-    minY = Math.min(minY, simulated.y);
-    maxX = Math.max(maxX, simulated.x + prop.width);
-    maxY = Math.max(maxY, simulated.y + prop.height);
+    const simulated = flowPositions.itemPositions.get(child) ?? measured;
+    maxX = Math.max(maxX, simulated.x + dimensions.width);
+    maxY = Math.max(maxY, simulated.y + dimensions.height);
   }
 
-  if (minX === Infinity || minY === Infinity) return { width: 0, height: 0 };
-  return { width: maxX - minX, height: maxY - minY };
+  if (ghost?.container === container && flowPositions.ghostPosition) {
+    maxX = Math.max(maxX, flowPositions.ghostPosition.x + ghost.width);
+    maxY = Math.max(maxY, flowPositions.ghostPosition.y + ghost.height);
+  }
+
+  const snapshotSize = {
+    width: containerProp.width,
+    height: containerProp.height,
+  };
+  const virtualSize = {
+    width:
+      containerProp.border.left +
+      containerProp.padding.left +
+      maxX +
+      containerProp.padding.right +
+      containerProp.border.right,
+    height:
+      containerProp.border.top +
+      containerProp.padding.top +
+      maxY +
+      containerProp.padding.bottom +
+      containerProp.border.bottom,
+  };
+
+  if (items.length === 0 && ghost?.container !== container) {
+    return snapshotSize;
+  }
+
+  if (axes.direction === "row") {
+    return {
+      width: snapshotSize.width,
+      height: Math.max(snapshotSize.height, virtualSize.height),
+    };
+  }
+
+  return {
+    width: snapshotSize.width,
+    height: virtualSize.height,
+  };
 }
 
 /**
@@ -880,6 +924,7 @@ export function virtualLayoutRecursive(
       startX,
       startY,
       {
+        container,
         index,
         width: dragGhostW,
         height: dragGhostH,

--- a/assets/snapsort/core/src/drop_target.ts
+++ b/assets/snapsort/core/src/drop_target.ts
@@ -10,28 +10,138 @@ const TAG_SNAPSHOT = "drop-snapshot"; // drag-start snapshot geometry and simula
 
 const snapshotDumpedForDrag = new WeakSet<ItemObject>();
 
+/**
+ * Allow the snapshot debug tree to be logged again for a new drag operation.
+ *
+ * @param item Item that is about to start dragging.
+ * @returns Nothing.
+ */
 export function resetDropSnapshotDebugDump(item: ItemObject) {
   snapshotDumpedForDrag.delete(item);
 }
 
-/** Get layout direction for a container. ItemContainer has a direction getter; default to "column". */
+/**
+ * Resolve the layout direction for a node that may or may not be an ItemContainer.
+ *
+ * @param node Item or container whose direction should be read.
+ * @returns `"row"` for row containers, otherwise `"column"` as the default.
+ */
 function getDirection(node: ItemObject): "column" | "row" {
   return "direction" in node && typeof (node as any).direction === "string"
     ? (node as any).direction
     : "column";
 }
 
-/** Euclidean distance between two points. */
+/**
+ * Measure straight-line distance between two points.
+ *
+ * @param x1 First point x-coordinate.
+ * @param y1 First point y-coordinate.
+ * @param x2 Second point x-coordinate.
+ * @param y2 Second point y-coordinate.
+ * @returns Euclidean distance between the two points.
+ */
 function euclidean(x1: number, y1: number, x2: number, y2: number): number {
   return Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
 }
 
+type AxisName = "x" | "y";
+type SizeName = "width" | "height";
+
+interface FlowAxes {
+  direction: "column" | "row";
+  main: AxisName;
+  cross: AxisName;
+  mainSize: SizeName;
+  crossSize: SizeName;
+}
+
+interface FlowMetrics {
+  mainStart: number;
+  crossStart: number;
+  mainGap: number;
+  crossGap: number;
+  lineCount: number;
+}
+
+interface FlowPositionResult {
+  itemPositions: Map<ItemObject, { x: number; y: number }>;
+  ghostPosition: { x: number; y: number } | null;
+}
+
+type FlowEntry =
+  | { kind: "item"; item: ItemObject; width: number; height: number }
+  | { kind: "ghost"; width: number; height: number };
+
+/**
+ * Convert a container direction into the axes used by the virtual layout.
+ *
+ * The rest of the algorithm can work in "main" and "cross" terms, which keeps
+ * row, column, row-wrap, and column-wrap behavior on the same code path.
+ *
+ * @param container Container whose direction determines the axis mapping.
+ * @returns Axis metadata used by the flow layout simulator.
+ */
+function flowAxes(container: ItemObject): FlowAxes {
+  const direction = getDirection(container);
+  if (direction === "row") {
+    return {
+      direction,
+      main: "x",
+      cross: "y",
+      mainSize: "width",
+      crossSize: "height",
+    };
+  }
+
+  return {
+    direction,
+    main: "y",
+    cross: "x",
+    mainSize: "height",
+    crossSize: "width",
+  };
+}
+
+/**
+ * Convert main/cross-axis coordinates back into an `{ x, y }` point.
+ *
+ * @param axes Axis mapping for the current container direction.
+ * @param main Coordinate on the layout's main axis.
+ * @param cross Coordinate on the layout's cross axis.
+ * @returns Absolute point in screen-space x/y coordinates.
+ */
+function pointFromAxes(
+  axes: FlowAxes,
+  main: number,
+  cross: number,
+): { x: number; y: number } {
+  return axes.main === "x" ? { x: main, y: cross } : { x: cross, y: main };
+}
+
+/**
+ * Check whether an item should be treated as a nested drop container.
+ *
+ * @param item Item to inspect.
+ * @returns True when the item has child items in either the frozen snapshot or live list.
+ */
 function isSubContainer(item: ItemObject) {
   return item.dragSnapshot
     ? item.dragSnapshotOrderedList.length > 0
     : item.itemOrderedList.length > 0;
 }
 
+/**
+ * Read an item's drag-start DOM snapshot or fail loudly if it is missing.
+ *
+ * All drop prediction must read from the drag-start snapshot. This guard keeps
+ * a missing snapshot from silently falling back to live DOM data, which would
+ * reintroduce frame-to-frame flicker while the ghost mutates the document.
+ *
+ * @param item Item whose frozen DOM geometry is required.
+ * @returns Cloned DOM property captured at drag start.
+ * @throws Error when drop prediction runs before snapshot capture.
+ */
 function requireDragSnapshot(item: ItemObject): DomProperty {
   const snapshot = item.dragSnapshot;
   if (!snapshot) {
@@ -42,6 +152,15 @@ function requireDragSnapshot(item: ItemObject): DomProperty {
   return snapshot;
 }
 
+/**
+ * Compute the content-box origin for a DOM snapshot.
+ *
+ * Flex children are laid out inside the content box, not the border box. The
+ * virtual layout uses this as the origin for every container it simulates.
+ *
+ * @param prop Frozen DOM property for a container.
+ * @returns Absolute x/y origin of the container's content box.
+ */
 function contentBoxOrigin(prop: DomProperty): { x: number; y: number } {
   return {
     x: prop.x + prop.border.left + prop.padding.left,
@@ -49,6 +168,12 @@ function contentBoxOrigin(prop: DomProperty): { x: number; y: number } {
   };
 }
 
+/**
+ * Compute the usable inner size for a DOM snapshot.
+ *
+ * @param prop Frozen DOM property for a container.
+ * @returns Width and height remaining after border and padding are removed.
+ */
 function contentBoxSize(prop: DomProperty): { width: number; height: number } {
   return {
     width: Math.max(
@@ -70,6 +195,15 @@ function contentBoxSize(prop: DomProperty): { width: number; height: number } {
   };
 }
 
+/**
+ * Convert a child's absolute snapshot position into a content-relative offset.
+ *
+ * This lets the same snapshot be replayed at any simulated container origin.
+ *
+ * @param containerProp Frozen DOM property for the parent container.
+ * @param childProp Frozen DOM property for the child item.
+ * @returns Child x/y offset from the parent's content-box origin.
+ */
 function childRelativeOffset(
   containerProp: DomProperty,
   childProp: DomProperty,
@@ -81,6 +215,17 @@ function childRelativeOffset(
   };
 }
 
+/**
+ * Return the frozen child list used for candidate indexing.
+ *
+ * Snapshot lists are the canonical ordering during a drag. Live item lists can
+ * contain the ghost or temporarily omit the dragged item, so candidate indices
+ * are always computed against this filtered frozen list.
+ *
+ * @param container Container whose snapshot children should be listed.
+ * @param draggedItem Item currently being dragged and excluded from layout.
+ * @returns Snapshot children without the dragged item or ghost items.
+ */
 function snapshotItems(
   container: ItemObject,
   draggedItem: ItemObject,
@@ -90,100 +235,15 @@ function snapshotItems(
   );
 }
 
-function isAfterDraggedInSameLine(
-  container: ItemObject,
-  item: ItemObject,
-  draggedItem: ItemObject,
-  isColumn: boolean,
-): boolean {
-  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
-  const itemIdx = ordered.indexOf(item);
-  const draggedIdx = ordered.indexOf(draggedItem);
-  if (itemIdx === -1 || draggedIdx === -1 || itemIdx <= draggedIdx) {
-    return false;
-  }
-  if (isColumn) return true;
-
-  const containerProp = requireDragSnapshot(container);
-  const itemOffset = childRelativeOffset(containerProp, requireDragSnapshot(item));
-  const draggedOffset = childRelativeOffset(
-    containerProp,
-    requireDragSnapshot(draggedItem),
-  );
-  return Math.abs(itemOffset.y - draggedOffset.y) <= 1;
-}
-
-function draggedGapSpan(
-  container: ItemObject,
-  draggedItem: ItemObject,
-  isColumn: boolean,
-): number {
-  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
-  const draggedIdx = ordered.indexOf(draggedItem);
-  if (draggedIdx === -1) return 0;
-
-  const containerProp = requireDragSnapshot(container);
-  const draggedProp = requireDragSnapshot(draggedItem);
-  const draggedOffset = childRelativeOffset(containerProp, draggedProp);
-  const next = ordered[draggedIdx + 1];
-
-  if (next) {
-    const nextOffset = childRelativeOffset(containerProp, requireDragSnapshot(next));
-    const sameLine = isColumn || Math.abs(nextOffset.y - draggedOffset.y) <= 1;
-    if (sameLine) {
-      const current = isColumn ? draggedOffset.y : draggedOffset.x;
-      const nextStart = isColumn ? nextOffset.y : nextOffset.x;
-      const span = nextStart - current;
-      if (span > 0) return span;
-    }
-  }
-
-  return isColumn ? draggedProp.height : draggedProp.width;
-}
-
-function closeDraggedGapPosition(
-  container: ItemObject,
-  item: ItemObject,
-  measuredPosition: { x: number; y: number },
-  draggedItem: ItemObject,
-  isColumn: boolean,
-): { x: number; y: number } {
-  if (item.locked) return measuredPosition;
-  if (!isAfterDraggedInSameLine(container, item, draggedItem, isColumn)) {
-    return measuredPosition;
-  }
-
-  const span = draggedGapSpan(container, draggedItem, isColumn);
-  return isColumn
-    ? { x: measuredPosition.x, y: measuredPosition.y - span }
-    : { x: measuredPosition.x - span, y: measuredPosition.y };
-}
-
-function gapAfter(
-  container: ItemObject,
-  item: ItemObject,
-  draggedItem: ItemObject,
-  isColumn: boolean,
-): number {
-  const items = snapshotItems(container, draggedItem);
-  const idx = items.indexOf(item);
-  if (idx === -1 || idx >= items.length - 1) return 0;
-
-  const containerProp = requireDragSnapshot(container);
-  const itemProp = requireDragSnapshot(item);
-  const nextProp = requireDragSnapshot(items[idx + 1]);
-  const itemOffset = childRelativeOffset(containerProp, itemProp);
-  const nextOffset = childRelativeOffset(containerProp, nextProp);
-
-  if (!isColumn && Math.abs(itemOffset.y - nextOffset.y) > 1) return 0;
-
-  const itemEnd = isColumn
-    ? itemOffset.y + itemProp.height
-    : itemOffset.x + itemProp.width;
-  const nextStart = isColumn ? nextOffset.y : nextOffset.x;
-  return Math.max(0, nextStart - itemEnd);
-}
-
+/**
+ * Compute the median number in a list.
+ *
+ * Median gaps are less sensitive than averages when one item has unusual
+ * margins or a flex line ends before the container edge.
+ *
+ * @param values Numeric values to summarize.
+ * @returns Median value, or `0` for an empty list.
+ */
 function median(values: number[]): number {
   if (values.length === 0) return 0;
   const sorted = values.slice().sort((a, b) => a - b);
@@ -193,91 +253,130 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
-function sameSnapshotRow(
-  containerProp: DomProperty,
-  a: ItemObject,
-  b: ItemObject,
-): boolean {
-  const aOffset = childRelativeOffset(containerProp, requireDragSnapshot(a));
-  const bOffset = childRelativeOffset(containerProp, requireDragSnapshot(b));
-  return Math.abs(aOffset.y - bOffset.y) <= 1;
-}
-
-function inferRowLayoutMetrics(container: ItemObject): {
-  rowStartX: number;
-  rowStartY: number;
-  columnGap: number;
-  rowGap: number;
-} {
+/**
+ * Decide whether two snapshot items occupy the same flex line.
+ *
+ * @param containerProp Frozen DOM property for the parent container.
+ * @param a First item to compare.
+ * @param b Second item to compare.
+ * @param axes Axis mapping for the parent container.
+ * @returns True when both items have effectively equal cross-axis starts.
+ */
+/**
+ * Infer flex line starts and gaps from the frozen DOM snapshot.
+ *
+ * CSS flexbox can be affected by margins and content size, so replaying
+ * measured gaps gives the virtual layout enough information without trying to
+ * parse every style.
+ *
+ * @param container Container whose frozen child geometry should be sampled.
+ * @param axes Axis mapping for the container direction.
+ * @returns Main/cross start offsets and median main/cross gaps.
+ */
+function inferFlowLayoutMetrics(
+  container: ItemObject,
+  axes: FlowAxes,
+): FlowMetrics {
   const containerProp = requireDragSnapshot(container);
   const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
   if (ordered.length === 0) {
-    return { rowStartX: 0, rowStartY: 0, columnGap: 0, rowGap: 0 };
+    return {
+      mainStart: 0,
+      crossStart: 0,
+      mainGap: 0,
+      crossGap: 0,
+      lineCount: 0,
+    };
   }
 
   const firstOffset = childRelativeOffset(
     containerProp,
     requireDragSnapshot(ordered[0]),
   );
-  const columnGaps: number[] = [];
-  const rows: Array<{ y: number; height: number }> = [];
-  let currentRow: { y: number; height: number } | null = null;
+  const mainGaps: number[] = [];
+  const lines: Array<{ cross: number; crossSize: number }> = [];
+  let currentLine: { cross: number; crossSize: number } | null = null;
+  let previousOffset: { x: number; y: number } | null = null;
 
   for (let i = 0; i < ordered.length; i++) {
     const item = ordered[i];
     const prop = requireDragSnapshot(item);
     const offset = childRelativeOffset(containerProp, prop);
-    if (!currentRow || Math.abs(offset.y - currentRow.y) > 1) {
-      currentRow = { y: offset.y, height: prop.height };
-      rows.push(currentRow);
+    const startsNewLine =
+      previousOffset != null &&
+      offset[axes.main] < previousOffset[axes.main] - 1;
+    if (!currentLine || startsNewLine) {
+      currentLine = {
+        cross: offset[axes.cross],
+        crossSize: prop[axes.crossSize],
+      };
+      lines.push(currentLine);
     } else {
-      currentRow.height = Math.max(currentRow.height, prop.height);
+      currentLine.crossSize = Math.max(
+        currentLine.crossSize,
+        prop[axes.crossSize],
+      );
     }
 
     const next = ordered[i + 1];
-    if (next && sameSnapshotRow(containerProp, item, next)) {
+    if (next) {
       const nextOffset = childRelativeOffset(
         containerProp,
         requireDragSnapshot(next),
       );
-      const gap = nextOffset.x - (offset.x + prop.width);
-      if (gap >= 0) columnGaps.push(gap);
+      const nextStartsNewLine = nextOffset[axes.main] < offset[axes.main] - 1;
+      if (!nextStartsNewLine) {
+        const gap =
+          nextOffset[axes.main] - (offset[axes.main] + prop[axes.mainSize]);
+        if (gap >= 0) mainGaps.push(gap);
+      }
     }
+    previousOffset = offset;
   }
 
-  const rowGaps: number[] = [];
-  for (let i = 0; i < rows.length - 1; i++) {
-    const gap = rows[i + 1].y - (rows[i].y + rows[i].height);
-    if (gap >= 0) rowGaps.push(gap);
+  const crossGaps: number[] = [];
+  for (let i = 0; i < lines.length - 1; i++) {
+    const gap = lines[i + 1].cross - (lines[i].cross + lines[i].crossSize);
+    if (gap >= 0) crossGaps.push(gap);
   }
 
   return {
-    rowStartX: firstOffset.x,
-    rowStartY: firstOffset.y,
-    columnGap: median(columnGaps),
-    rowGap: median(rowGaps),
+    mainStart: firstOffset[axes.main],
+    crossStart: firstOffset[axes.cross],
+    mainGap: median(mainGaps),
+    crossGap: median(crossGaps),
+    lineCount: lines.length,
   };
 }
 
-function rowLayoutPositions(
+/**
+ * Replay flex layout from the frozen snapshot.
+ *
+ * The dragged item is omitted, and a virtual ghost can be inserted at a
+ * candidate index. This is the shared layout engine for rows and columns; only
+ * the main/cross axes change.
+ *
+ * @param container Container whose children are being simulated.
+ * @param draggedItem Item excluded from the simulated flow.
+ * @param startX Absolute x-coordinate of the container content origin.
+ * @param startY Absolute y-coordinate of the container content origin.
+ * @param ghost Optional virtual ghost insertion to test.
+ * @returns Simulated item positions and the simulated ghost position, if any.
+ */
+function flowLayoutPositions(
   container: ItemObject,
   draggedItem: ItemObject,
   startX: number,
   startY: number,
   ghost?: { index: number; width: number; height: number },
-): {
-  itemPositions: Map<ItemObject, { x: number; y: number }>;
-  ghostPosition: { x: number; y: number } | null;
-} {
+): FlowPositionResult {
+  const axes = flowAxes(container);
   const containerProp = requireDragSnapshot(container);
   const contentSize = contentBoxSize(containerProp);
   const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
   const items = ordered.filter((i) => i !== draggedItem);
-  const metrics = inferRowLayoutMetrics(container);
-  const entries: Array<
-    | { kind: "item"; item: ItemObject; width: number; height: number }
-    | { kind: "ghost"; width: number; height: number }
-  > = items.map((item) => {
+  const metrics = inferFlowLayoutMetrics(container, axes);
+  const entries: FlowEntry[] = items.map((item) => {
     const prop = requireDragSnapshot(item);
     return { kind: "item", item, width: prop.width, height: prop.height };
   });
@@ -292,29 +391,35 @@ function rowLayoutPositions(
 
   const itemPositions = new Map<ItemObject, { x: number; y: number }>();
   let ghostPosition: { x: number; y: number } | null = null;
-  const rowStartX = startX + metrics.rowStartX;
-  const maxX = startX + contentSize.width;
-  let cursorX = rowStartX;
-  let cursorY = startY + metrics.rowStartY;
-  let rowHeight = 0;
+  const origin = { x: startX, y: startY };
+  const lineMainStart = origin[axes.main] + metrics.mainStart;
+  const lineCrossStart = origin[axes.cross] + metrics.crossStart;
+  const maxMain = origin[axes.main] + contentSize[axes.mainSize];
+  const canWrap = axes.direction === "row" || metrics.lineCount > 1;
+  let cursorMain = lineMainStart;
+  let cursorCross = lineCrossStart;
+  let lineCrossSize = 0;
 
   for (const entry of entries) {
+    const entryMainSize = entry[axes.mainSize];
+    const entryCrossSize = entry[axes.crossSize];
     if (
-      cursorX > rowStartX + 0.5 &&
-      cursorX + entry.width > maxX + 0.5
+      canWrap &&
+      cursorMain > lineMainStart + 0.5 &&
+      cursorMain + entryMainSize > maxMain + 0.5
     ) {
-      cursorX = rowStartX;
-      cursorY += rowHeight + metrics.rowGap;
-      rowHeight = 0;
+      cursorMain = lineMainStart;
+      cursorCross += lineCrossSize + metrics.crossGap;
+      lineCrossSize = 0;
     }
 
-    let position = { x: cursorX, y: cursorY };
+    let position = pointFromAxes(axes, cursorMain, cursorCross);
     if (entry.kind === "item" && entry.item.locked) {
       const prop = requireDragSnapshot(entry.item);
       const rel = childRelativeOffset(containerProp, prop);
       position = { x: startX + rel.x, y: startY + rel.y };
-      cursorX = position.x;
-      cursorY = position.y;
+      cursorMain = position[axes.main];
+      cursorCross = position[axes.cross];
     }
 
     if (entry.kind === "ghost") {
@@ -323,13 +428,22 @@ function rowLayoutPositions(
       itemPositions.set(entry.item, position);
     }
 
-    cursorX += entry.width + metrics.columnGap;
-    rowHeight = Math.max(rowHeight, entry.height);
+    cursorMain += entryMainSize + metrics.mainGap;
+    lineCrossSize = Math.max(lineCrossSize, entryCrossSize);
   }
 
   return { itemPositions, ghostPosition };
 }
 
+/**
+ * Build a content-box rectangle for a container snapshot.
+ *
+ * Candidate tie-breaks use the same content box that virtual layout uses; this
+ * avoids favoring a parent merely because of padding or border area.
+ *
+ * @param container Container whose content rectangle should be read.
+ * @returns Absolute content-box rectangle.
+ */
 function containerContentRect(container: ItemObject) {
   const prop = requireDragSnapshot(container);
   const origin = contentBoxOrigin(prop);
@@ -337,6 +451,14 @@ function containerContentRect(container: ItemObject) {
   return { ...origin, ...size };
 }
 
+/**
+ * Check whether a point falls inside a rectangle.
+ *
+ * @param rect Rectangle to test.
+ * @param x Point x-coordinate.
+ * @param y Point y-coordinate.
+ * @returns True when the point is inside or on the rectangle edge.
+ */
 function containsPoint(
   rect: { x: number; y: number; width: number; height: number },
   x: number,
@@ -350,6 +472,17 @@ function containsPoint(
   );
 }
 
+/**
+ * Measure how close a point is to a container content rectangle.
+ *
+ * Points inside the rectangle return distance to the nearest inner edge. Points
+ * outside return distance to the nearest point on the rectangle.
+ *
+ * @param rect Content rectangle to compare against.
+ * @param x Point x-coordinate.
+ * @param y Point y-coordinate.
+ * @returns Distance to the nearest content-box edge or clamped point.
+ */
 function distanceToNearestContentEdge(
   rect: { x: number; y: number; width: number; height: number },
   x: number,
@@ -368,6 +501,18 @@ function distanceToNearestContentEdge(
   return euclidean(x, y, clampedX, clampedY);
 }
 
+/**
+ * Break close-distance ties between candidates from different containers.
+ *
+ * The candidate whose container content box contains the drag center wins. If
+ * both or neither contain it, the candidate closer to a content-box edge wins.
+ *
+ * @param a First candidate.
+ * @param b Second candidate.
+ * @param dragCenterX Current dragged item center x-coordinate.
+ * @param dragCenterY Current dragged item center y-coordinate.
+ * @returns The preferred candidate.
+ */
 function chooseByContentBox(
   a: DropCandidate,
   b: DropCandidate,
@@ -386,6 +531,15 @@ function chooseByContentBox(
   return a.distance <= b.distance ? a : b;
 }
 
+/**
+ * Draw measured-vs-simulated snapshot geometry for one item.
+ *
+ * @param container Container whose virtual pass is drawing the item.
+ * @param item Item being drawn.
+ * @param measuredPosition Absolute position from the frozen DOM snapshot.
+ * @param simulatedPosition Absolute position from the virtual layout replay.
+ * @returns Nothing.
+ */
 function drawSnapshotDebug(
   container: ItemObject,
   item: ItemObject,
@@ -430,6 +584,13 @@ function drawSnapshotDebug(
   );
 }
 
+/**
+ * Draw the simulated content box for a container.
+ *
+ * @param container Container whose content box should be drawn.
+ * @param origin Absolute x/y content origin used by the virtual layout.
+ * @returns Nothing.
+ */
 function drawContainerContentBox(
   container: ItemObject,
   origin: { x: number; y: number },
@@ -449,6 +610,13 @@ function drawContainerContentBox(
   );
 }
 
+/**
+ * Log the frozen snapshot tree once per drag for debugging.
+ *
+ * @param item Item currently being dragged.
+ * @param root Root container whose snapshot tree should be dumped.
+ * @returns Nothing.
+ */
 function dumpSnapshotOnce(item: ItemObject, root: ItemObject) {
   if (snapshotDumpedForDrag.has(item)) return;
   snapshotDumpedForDrag.add(item);
@@ -488,6 +656,9 @@ const LAYOUT_TRACE = true;
  * Shows the container's items in order with their measured DOM bounds and a
  * `►` arrow at the ghost insertion slot, so it's clear which slot the
  * candidate's `index`, `ghostCenter`, and `distance` correspond to.
+ *
+ * @param args Candidate trace payload with container, layout, ghost, and pointer data.
+ * @returns Nothing.
  */
 function logCandidateSnapshot(args: {
   container: ItemObject;
@@ -592,15 +763,6 @@ export interface VirtualDimensions {
   height: number;
 }
 
-interface VirtualNode {
-  containerGID: string;
-  item: ItemObject | null;
-  prop: DomProperty | null;
-  position: { x: number; y: number } | null;
-  previous: VirtualNode | null;
-  next: VirtualNode | null;
-}
-
 export interface DropCandidate {
   container: ItemObject;
   index: number;
@@ -608,26 +770,31 @@ export interface DropCandidate {
   ghostCenterY: number;
   distance: number;
   priority: number; // Higher priority wins on ties. Normal candidates = 0, special cases = 999.
-  virtualNode: VirtualNode;
   prevPosition: { x: number; y: number } | null;
   nextPosition: { x: number; y: number } | null;
 }
 
 /**
  * Recursively compute the virtual dimensions (width and height) of a container
- * by simulating its flex layout, including wrapping for row containers.
+ * by simulating its flex layout, including wrapping on the main axis.
  * Excludes the dragged item and ghost items.
+ *
+ * @param container Container whose children should be simulated.
+ * @param draggedItem Item currently being dragged and omitted from layout.
+ * @returns Virtual width and height of the remaining children.
  */
 export function virtualDimensions(
   container: ItemObject,
   draggedItem: ItemObject,
 ): VirtualDimensions {
-  const isColumn = getDirection(container) === "column";
   const containerProp = requireDragSnapshot(container);
   const items = snapshotItems(container, draggedItem);
-  const rowPositions = isColumn
-    ? null
-    : rowLayoutPositions(container, draggedItem, 0, 0).itemPositions;
+  const flowPositions = flowLayoutPositions(
+    container,
+    draggedItem,
+    0,
+    0,
+  ).itemPositions;
   let minX = Infinity;
   let minY = Infinity;
   let maxX = 0;
@@ -637,15 +804,7 @@ export function virtualDimensions(
     const prop = requireDragSnapshot(child);
     const rel = childRelativeOffset(containerProp, prop);
     const measured = { x: rel.x, y: rel.y };
-    const simulated =
-      rowPositions?.get(child) ??
-      closeDraggedGapPosition(
-        container,
-        child,
-        measured,
-        draggedItem,
-        isColumn,
-      );
+    const simulated = flowPositions.get(child) ?? measured;
     minX = Math.min(minX, simulated.x);
     minY = Math.min(minY, simulated.y);
     maxX = Math.max(maxX, simulated.x + prop.width);
@@ -657,58 +816,46 @@ export function virtualDimensions(
 }
 
 /**
- * Recursively simulate the layout of a container, including wrapping for row containers.
- * Only try ghost placement at slots adjacent to items in the colliding set.
+ * Recursively simulate a container's layout, including wrapping on the main axis.
  *
- * Each visited item becomes a `VirtualNode` and is appended to a doubly-linked
- * list passed in via `node`. As we descend into sub-containers we keep walking
- * the same chain, so when a candidate is produced the linked list looks like:
- *
- *     ... ─ prev ─ current ─ next ─ ...
- *            ▲       ▲        ▲
- *            │       │        └─ unset until the next iteration appends it
- *            │       └─ the just-placed item (== `node` at candidate time)
- *            └─ node.previous, used to anchor the BEFORE/AFTER snap targets
- *
- * For every item in `collidingSet` we emit two candidates — one with the ghost
- * inserted just BEFORE that item (idx = j), and one just AFTER (idx = j+1) —
- * along with `prevPosition`/`nextPosition` snap anchors. See the inline ASCII
- * diagrams in the column branch below.
+ * For every unlocked item we emit two candidates — one with the ghost
+ * inserted just BEFORE that item (idx = j), and one just AFTER (idx = j+1).
+ * Each candidate is scored by where the virtual layout places the ghost.
  *
  * @param container   The container to lay out
- * @param node        Tail of the virtual linked list to extend
  * @param startX      The X origin of this container's content area
  * @param startY      The Y origin of this container's content area
  * @param draggedItem The item being dragged (excluded from layout)
  * @param dragGhostW  Width of the ghost element (dragged item's width)
  * @param dragGhostH  Height of the ghost element (dragged item's height)
- * @param collidingSet Items currently colliding with the dragged item
  * @param dragCenterX Dragged item's center X
  * @param dragCenterY Dragged item's center Y
+ * @returns Drop candidates found in this subtree and the simulated container end point.
  */
 export function virtualLayoutRecursive(
   container: ItemObject,
-  node: VirtualNode,
   startX: number,
   startY: number,
   draggedItem: ItemObject,
   dragGhostW: number,
   dragGhostH: number,
-  collidingSet: Set<ItemObject>,
   dragCenterX: number,
   dragCenterY: number,
 ): { candidates: DropCandidate[]; endX: number; endY: number } {
-  const isColumn = getDirection(container) === "column";
+  const axes = flowAxes(container);
+  const isColumn = axes.direction === "column";
   const containerProp = requireDragSnapshot(container);
   const contentSize = contentBoxSize(containerProp);
   const containerWidth = contentSize.width;
   const items = snapshotItems(container, draggedItem);
-  const rowPositions = isColumn
-    ? null
-    : rowLayoutPositions(container, draggedItem, startX, startY).itemPositions;
+  const flowPositions = flowLayoutPositions(
+    container,
+    draggedItem,
+    startX,
+    startY,
+  ).itemPositions;
 
-  const thisCandidates: DropCandidate[] = [];
-  const childCandidates: DropCandidate[] = [];
+  const candidates: DropCandidate[] = [];
   const layoutItems: Array<{
     item: ItemObject;
     measuredPosition: { x: number; y: number };
@@ -723,67 +870,56 @@ export function virtualLayoutRecursive(
     container.clearDebugMarker(`vlayout-ghost-after-${container.gid}-${j}`);
   }
 
+  const makeCandidate = (
+    index: number,
+    fallbackPosition: { x: number; y: number },
+  ): DropCandidate => {
+    const ghostPosition = flowLayoutPositions(
+      container,
+      draggedItem,
+      startX,
+      startY,
+      {
+        index,
+        width: dragGhostW,
+        height: dragGhostH,
+      },
+    ).ghostPosition;
+    const ghostX = ghostPosition?.x ?? fallbackPosition.x;
+    const ghostY = ghostPosition?.y ?? fallbackPosition.y;
+    const gcx = ghostX + dragGhostW / 2;
+    const gcy = ghostY + dragGhostH / 2;
+    const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
+    const nextPosition = isColumn
+      ? { x: ghostX, y: ghostY + dragGhostH }
+      : { x: ghostX + dragGhostW, y: ghostY };
+
+    return {
+      container,
+      index,
+      ghostCenterX: gcx,
+      ghostCenterY: gcy,
+      distance: dist,
+      priority: 0,
+      prevPosition: null,
+      nextPosition,
+    };
+  };
+
   for (let j = 0; j < items.length; j++) {
     const item = items[j];
-    const isColliding = collidingSet.has(item);
+    const canPlaceCandidate = !item.locked;
     const prop = requireDragSnapshot(item);
     const isContainer = isSubContainer(item);
     const rel = childRelativeOffset(containerProp, prop);
     const measuredPosition = { x: startX + rel.x, y: startY + rel.y };
-    const simulatedPosition =
-      rowPositions?.get(item) ??
-      closeDraggedGapPosition(
-        container,
-        item,
-        measuredPosition,
-        draggedItem,
-        isColumn,
-      );
+    const simulatedPosition = flowPositions.get(item) ?? measuredPosition;
     layoutItems.push({ item, measuredPosition, simulatedPosition });
     drawSnapshotDebug(container, item, measuredPosition, simulatedPosition);
 
-    const newNode: VirtualNode = {
-      containerGID: container.gid,
-      item,
-      prop,
-      position: simulatedPosition,
-      previous: node,
-      next: null,
-    };
-    const prevNode = isContainer ? node : node.previous;
-    if (!isContainer) {
-      node.next = newNode;
-      node = newNode;
-    }
-
-    if (isColliding && !item.locked) {
-      const rowGhostPosition = isColumn
-        ? null
-        : rowLayoutPositions(container, draggedItem, startX, startY, {
-            index: j,
-            width: dragGhostW,
-            height: dragGhostH,
-          }).ghostPosition;
-      const ghostX = rowGhostPosition?.x ?? simulatedPosition.x;
-      const ghostY = rowGhostPosition?.y ?? simulatedPosition.y;
-      const gcx = ghostX + dragGhostW / 2;
-      const gcy = ghostY + dragGhostH / 2;
-      const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
-      const nextPosition = isColumn
-        ? { x: ghostX, y: ghostY + dragGhostH }
-        : { x: ghostX + dragGhostW, y: ghostY };
-
-      thisCandidates.push({
-        container,
-        index: j,
-        ghostCenterX: gcx,
-        ghostCenterY: gcy,
-        distance: dist,
-        priority: 0,
-        virtualNode: isContainer ? newNode : node,
-        prevPosition: prevNode && prevNode.position ? prevNode.position : null,
-        nextPosition,
-      });
+    if (canPlaceCandidate) {
+      const beforeCandidate = makeCandidate(j, simulatedPosition);
+      candidates.push(beforeCandidate);
       logCandidateSnapshot({
         container,
         items,
@@ -792,19 +928,19 @@ export function virtualLayoutRecursive(
         startX,
         startY,
         containerWidth,
-        ghostCenterX: gcx,
-        ghostCenterY: gcy,
+        ghostCenterX: beforeCandidate.ghostCenterX,
+        ghostCenterY: beforeCandidate.ghostCenterY,
         ghostW: dragGhostW,
         ghostH: dragGhostH,
-        distance: dist,
-        priority: 0,
+        distance: beforeCandidate.distance,
+        priority: beforeCandidate.priority,
         dragCenterX,
         dragCenterY,
         layoutItems,
       });
       container.addDebugRect(
-        ghostX,
-        ghostY,
+        beforeCandidate.ghostCenterX - dragGhostW / 2,
+        beforeCandidate.ghostCenterY - dragGhostH / 2,
         isColumn ? containerWidth : dragGhostW,
         isColumn ? dragGhostH : dragGhostH,
         "rgba(250, 204, 21, 0.15)",
@@ -823,20 +959,15 @@ export function virtualLayoutRecursive(
       };
       const sub = virtualLayoutRecursive(
         item,
-        node,
         childOrigin.x,
         childOrigin.y,
         draggedItem,
         dragGhostW,
         dragGhostH,
-        collidingSet,
         dragCenterX,
         dragCenterY,
       );
-      childCandidates.push(...sub.candidates);
-      while (node.next) {
-        node = node.next;
-      }
+      candidates.push(...sub.candidates);
     }
 
     const barX = startX - 6 + container.depth * 10;
@@ -885,39 +1016,13 @@ export function virtualLayoutRecursive(
       );
     }
 
-    if (isColliding && !item.locked) {
-      const gap = gapAfter(container, item, draggedItem, isColumn);
-      const rowGhostPosition = isColumn
-        ? null
-        : rowLayoutPositions(container, draggedItem, startX, startY, {
-            index: j + 1,
-            width: dragGhostW,
-            height: dragGhostH,
-          }).ghostPosition;
-      const ghostX =
-        rowGhostPosition?.x ??
-        (isColumn ? simulatedPosition.x : simulatedPosition.x + prop.width + gap);
-      const ghostY =
-        rowGhostPosition?.y ??
-        (isColumn ? simulatedPosition.y + prop.height + gap : simulatedPosition.y);
-      const gcx = ghostX + dragGhostW / 2;
-      const gcy = ghostY + dragGhostH / 2;
-      const dist = euclidean(gcx, gcy, dragCenterX, dragCenterY);
-      const nextPosition = isColumn
-        ? { x: ghostX, y: ghostY + dragGhostH }
-        : { x: ghostX + dragGhostW, y: ghostY };
-
-      thisCandidates.push({
-        container,
-        index: j + 1,
-        ghostCenterX: gcx,
-        ghostCenterY: gcy,
-        distance: dist,
-        priority: 0,
-        virtualNode: isContainer ? newNode : node,
-        prevPosition: simulatedPosition,
-        nextPosition,
-      });
+    if (canPlaceCandidate) {
+      const fallbackMain =
+        simulatedPosition[axes.main] + prop[axes.mainSize];
+      const fallbackCross = simulatedPosition[axes.cross];
+      const fallbackPosition = pointFromAxes(axes, fallbackMain, fallbackCross);
+      const afterCandidate = makeCandidate(j + 1, fallbackPosition);
+      candidates.push(afterCandidate);
       logCandidateSnapshot({
         container,
         items,
@@ -926,19 +1031,19 @@ export function virtualLayoutRecursive(
         startX,
         startY,
         containerWidth,
-        ghostCenterX: gcx,
-        ghostCenterY: gcy,
+        ghostCenterX: afterCandidate.ghostCenterX,
+        ghostCenterY: afterCandidate.ghostCenterY,
         ghostW: dragGhostW,
         ghostH: dragGhostH,
-        distance: dist,
-        priority: 0,
+        distance: afterCandidate.distance,
+        priority: afterCandidate.priority,
         dragCenterX,
         dragCenterY,
         layoutItems,
       });
       container.addDebugRect(
-        ghostX,
-        ghostY,
+        afterCandidate.ghostCenterX - dragGhostW / 2,
+        afterCandidate.ghostCenterY - dragGhostH / 2,
         isColumn ? containerWidth : dragGhostW,
         dragGhostH,
         "rgba(250, 204, 21, 0.15)",
@@ -951,11 +1056,10 @@ export function virtualLayoutRecursive(
     }
   }
 
-  const candidates = container.noDrop
-    ? childCandidates
-    : childCandidates.concat(thisCandidates);
   return {
-    candidates,
+    candidates: container.noDrop
+      ? candidates.filter((candidate) => candidate.container !== container)
+      : candidates,
     endX: startX + contentSize.width,
     endY: startY + contentSize.height,
   };
@@ -964,24 +1068,15 @@ export function virtualLayoutRecursive(
 /**
  * Determine the container and index to drop the item into based on
  * the current mouse position. Draws debug visuals and returns the best candidate.
+ *
+ * @param item Item currently being dragged.
+ * @param root Root container that owns the drag snapshot tree.
+ * @returns Best drop candidate for the current frame, or null when there is no valid target.
  */
 export function determineDropTarget(
   item: ItemObject,
   root: ItemObject,
 ): DropCandidate | null {
-  // Collect colliding items
-  const collidingSet = new Set<ItemObject>();
-  for (const other of item.hitbox.currentCollisions) {
-    const otherItem = other.parent;
-    if (otherItem instanceof (item.constructor as any) && otherItem !== item) {
-      collidingSet.add(otherItem as ItemObject);
-    }
-  }
-
-  console.debug(
-    `Colliding with: ${Array.from(collidingSet.values().map((i) => i.gid)).join(",")}`,
-  );
-
   let best: DropCandidate | null = null;
 
   const rootProp = requireDragSnapshot(root);
@@ -1007,25 +1102,14 @@ export function determineDropTarget(
     );
   }
 
-  const head: VirtualNode = {
-    containerGID: "",
-    item: null,
-    prop: null,
-    position: null,
-    previous: null,
-    next: null,
-  };
-
   // Run the virtual layout algorithm
   const { candidates: virtualCandidates } = virtualLayoutRecursive(
     root,
-    head,
     layoutOrigin.x,
     layoutOrigin.y,
     item,
     dragGhostW,
     dragGhostH,
-    collidingSet,
     dragCenterX,
     dragCenterY,
   );
@@ -1146,11 +1230,10 @@ export function determineDropTarget(
         `drop-neighbor-prev-${i}`,
         TAG_NEIGHBORS,
       );
-      const prevGid = c.virtualNode?.previous?.item?.gid ?? "·";
       root.addDebugText(
         c.prevPosition.x + 8,
         c.prevPosition.y - 4,
-        `${isBest ? "▲ " : ""}prev[${i}]=${prevGid}`,
+        `${isBest ? "▲ " : ""}prev[${i}]`,
         prevColor,
         true,
         `drop-neighbor-prev-label-${i}`,
@@ -1179,11 +1262,10 @@ export function determineDropTarget(
         `drop-neighbor-next-${i}`,
         TAG_NEIGHBORS,
       );
-      const nextGid = c.virtualNode?.next?.item?.gid ?? "·";
       root.addDebugText(
         c.nextPosition.x + 8,
         c.nextPosition.y + 12,
-        `${isBest ? "▼ " : ""}next[${i}]=${nextGid}`,
+        `${isBest ? "▼ " : ""}next[${i}]`,
         nextColor,
         true,
         `drop-neighbor-next-label-${i}`,
@@ -1206,8 +1288,8 @@ export function determineDropTarget(
     item.clearDebugMarker(`drop-result`);
   }
 
-  // --- Debug: collision visuals ---
-  debugDropTargetTree(root, item, collidingSet);
+  // --- Debug: layout item visuals ---
+  debugDropTargetTree(root, item);
 
   const dragTx = item.transform.x;
   const dragTy = item.transform.y;
@@ -1234,65 +1316,19 @@ export function determineDropTarget(
     TAG_COLLISIONS,
   );
 
-  const dragCpX = dragTx + item.centerPoint.local.x;
-  const dragCpY = dragTy + item.centerPoint.local.y;
-
-  for (const other of item.hitbox.currentCollisions) {
-    const otherParent = other.parent as ItemObject;
-    if (!otherParent || otherParent === item) continue;
-    if (!collidingSet.has(otherParent)) continue;
-
-    const otherTx = otherParent.transform.x;
-    const otherTy = otherParent.transform.y;
-    const otherCpX = otherTx + otherParent.centerPoint.local.x;
-    const otherCpY = otherTy + otherParent.centerPoint.local.y;
-
-    item.addDebugLine(
-      dragCpX,
-      dragCpY,
-      otherCpX,
-      otherCpY,
-      "rgba(251, 146, 60, 0.7)",
-      true,
-      `drop-collision-line-${otherParent.gid}`,
-      2,
-      TAG_COLLISIONS,
-    );
-
-    const otherHb = otherParent.hitbox;
-    otherParent.addDebugRect(
-      otherTx + otherHb.local.x,
-      otherTy + otherHb.local.y,
-      otherHb.local.width,
-      otherHb.local.height,
-      "rgba(251, 146, 60, 0.5)",
-      true,
-      `drop-colliding-${otherParent.gid}`,
-      false,
-      2,
-      TAG_COLLISIONS,
-    );
-    otherParent.addDebugText(
-      otherTx + otherHb.local.x + 2,
-      otherTy + otherHb.local.y + otherHb.local.height + 12,
-      `COLLIDING ${otherParent.gid}`,
-      "rgba(251, 146, 60, 0.9)",
-      true,
-      `drop-colliding-label-${otherParent.gid}`,
-      TAG_COLLISIONS,
-    );
-  }
-
   return best;
 }
 
 /**
  * Draw debug visuals for every item in the hierarchy.
+ *
+ * @param node Current node whose descendants should be drawn.
+ * @param draggedItem Item currently being dragged.
+ * @returns Nothing.
  */
 export function debugDropTargetTree(
   node: ItemObject,
   draggedItem: ItemObject,
-  collidingItems: Set<ItemObject>,
 ) {
   const items = node.itemOrderedList.filter(
     (i) => i !== draggedItem && !i.isGhost,
@@ -1354,14 +1390,12 @@ export function debugDropTargetTree(
       TAG_COLLISIONS,
     );
 
-    if (!collidingItems.has(item)) {
-      draggedItem.clearDebugMarker(`drop-collision-line-${item.gid}`);
-      item.clearDebugMarker(`drop-colliding-${item.gid}`);
-      item.clearDebugMarker(`drop-colliding-label-${item.gid}`);
-    }
+    draggedItem.clearDebugMarker(`drop-collision-line-${item.gid}`);
+    item.clearDebugMarker(`drop-colliding-${item.gid}`);
+    item.clearDebugMarker(`drop-colliding-label-${item.gid}`);
 
     if (item.children.length > 0) {
-      debugDropTargetTree(item, draggedItem, collidingItems);
+      debugDropTargetTree(item, draggedItem);
     }
   }
 }

--- a/assets/snapsort/core/src/drop_target.ts
+++ b/assets/snapsort/core/src/drop_target.ts
@@ -1,5 +1,17 @@
 import type { ItemObject } from "./item";
 import type { DomProperty } from "@snap-engine/core";
+import {
+  childRelativeOffset,
+  contentBoxOrigin,
+  contentBoxSize,
+  flowAxesForDirection,
+  flowLayoutPositions,
+  layoutItems,
+  pointFromAxes,
+  virtualDimensions as layoutVirtualDimensions,
+  type LayoutNode,
+  type VirtualGhost as LayoutVirtualGhost,
+} from "./layout_engine";
 
 // Sub-tags for drop index calculation debug visuals
 const TAG_LAYOUT = "drop-layout"; // virtual layout: height bars, layout start lines, ghost positions
@@ -9,6 +21,7 @@ const TAG_NEIGHBORS = "drop-neighbors"; // per-candidate prev/next reference poi
 const TAG_SNAPSHOT = "drop-snapshot"; // drag-start snapshot geometry and simulation deltas
 
 const snapshotDumpedForDrag = new WeakSet<ItemObject>();
+const SNAPSHOT_DUMP_TRACE = false;
 
 /**
  * Allow the snapshot debug tree to be logged again for a new drag operation.
@@ -45,85 +58,11 @@ function euclidean(x1: number, y1: number, x2: number, y2: number): number {
   return Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
 }
 
-type AxisName = "x" | "y";
-type SizeName = "width" | "height";
-
-interface FlowAxes {
-  direction: "column" | "row";
-  main: AxisName;
-  cross: AxisName;
-  mainSize: SizeName;
-  crossSize: SizeName;
-}
-
-interface FlowMetrics {
-  mainStart: number;
-  crossStart: number;
-  mainGap: number;
-  crossGap: number;
-  lineCount: number;
-}
-
-interface FlowPositionResult {
-  itemPositions: Map<ItemObject, { x: number; y: number }>;
-  ghostPosition: { x: number; y: number } | null;
-}
-
 export interface VirtualGhost {
   container: ItemObject;
   index: number;
   width: number;
   height: number;
-}
-
-type FlowEntry =
-  | { kind: "item"; item: ItemObject; width: number; height: number }
-  | { kind: "ghost"; width: number; height: number };
-
-/**
- * Convert a container direction into the axes used by the virtual layout.
- *
- * The rest of the algorithm can work in "main" and "cross" terms, which keeps
- * row, column, row-wrap, and column-wrap behavior on the same code path.
- *
- * @param container Container whose direction determines the axis mapping.
- * @returns Axis metadata used by the flow layout simulator.
- */
-function flowAxes(container: ItemObject): FlowAxes {
-  const direction = getDirection(container);
-  if (direction === "row") {
-    return {
-      direction,
-      main: "x",
-      cross: "y",
-      mainSize: "width",
-      crossSize: "height",
-    };
-  }
-
-  return {
-    direction,
-    main: "y",
-    cross: "x",
-    mainSize: "height",
-    crossSize: "width",
-  };
-}
-
-/**
- * Convert main/cross-axis coordinates back into an `{ x, y }` point.
- *
- * @param axes Axis mapping for the current container direction.
- * @param main Coordinate on the layout's main axis.
- * @param cross Coordinate on the layout's cross axis.
- * @returns Absolute point in screen-space x/y coordinates.
- */
-function pointFromAxes(
-  axes: FlowAxes,
-  main: number,
-  cross: number,
-): { x: number; y: number } {
-  return axes.main === "x" ? { x: main, y: cross } : { x: cross, y: main };
 }
 
 /**
@@ -159,285 +98,45 @@ function requireDragSnapshot(item: ItemObject): DomProperty {
   return snapshot;
 }
 
-/**
- * Compute the content-box origin for a DOM snapshot.
- *
- * Flex children are laid out inside the content box, not the border box. The
- * virtual layout uses this as the origin for every container it simulates.
- *
- * @param prop Frozen DOM property for a container.
- * @returns Absolute x/y origin of the container's content box.
- */
-function contentBoxOrigin(prop: DomProperty): { x: number; y: number } {
-  return {
-    x: prop.x + prop.border.left + prop.padding.left,
-    y: prop.y + prop.border.top + prop.padding.top,
-  };
+function flowAxes(container: ItemObject) {
+  return flowAxesForDirection(getDirection(container));
 }
 
-/**
- * Compute the usable inner size for a DOM snapshot.
- *
- * @param prop Frozen DOM property for a container.
- * @returns Width and height remaining after border and padding are removed.
- */
-function contentBoxSize(prop: DomProperty): { width: number; height: number } {
-  return {
-    width: Math.max(
-      0,
-      prop.width -
-        prop.border.left -
-        prop.border.right -
-        prop.padding.left -
-        prop.padding.right,
-    ),
-    height: Math.max(
-      0,
-      prop.height -
-        prop.border.top -
-        prop.border.bottom -
-        prop.padding.top -
-        prop.padding.bottom,
-    ),
-  };
-}
-
-/**
- * Convert a child's absolute snapshot position into a content-relative offset.
- *
- * This lets the same snapshot be replayed at any simulated container origin.
- *
- * @param containerProp Frozen DOM property for the parent container.
- * @param childProp Frozen DOM property for the child item.
- * @returns Child x/y offset from the parent's content-box origin.
- */
-function childRelativeOffset(
-  containerProp: DomProperty,
-  childProp: DomProperty,
-): { x: number; y: number } {
-  const origin = contentBoxOrigin(containerProp);
-  return {
-    x: childProp.x - origin.x,
-    y: childProp.y - origin.y,
-  };
-}
-
-/**
- * Return the frozen child list used for candidate indexing.
- *
- * Snapshot lists are the canonical ordering during a drag. Live item lists can
- * contain the ghost or temporarily omit the dragged item, so candidate indices
- * are always computed against this filtered frozen list.
- *
- * @param container Container whose snapshot children should be listed.
- * @param draggedItem Item currently being dragged and excluded from layout.
- * @returns Snapshot children without the dragged item or ghost items.
- */
-function snapshotItems(
-  container: ItemObject,
-  draggedItem: ItemObject,
-): ItemObject[] {
-  return container.dragSnapshotOrderedList.filter(
-    (i) => i !== draggedItem && !i.isGhost,
-  );
-}
-
-/**
- * Compute the median number in a list.
- *
- * Median gaps are less sensitive than averages when one item has unusual
- * margins or a flex line ends before the container edge.
- *
- * @param values Numeric values to summarize.
- * @returns Median value, or `0` for an empty list.
- */
-function median(values: number[]): number {
-  if (values.length === 0) return 0;
-  const sorted = values.slice().sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[mid - 1] + sorted[mid]) / 2
-    : sorted[mid];
-}
-
-/**
- * Infer flex line starts and gaps from the frozen DOM snapshot.
- *
- * CSS flexbox can be affected by margins and content size, so replaying
- * measured gaps gives the virtual layout enough information without trying to
- * parse every style.
- *
- * @param container Container whose frozen child geometry should be sampled.
- * @param axes Axis mapping for the container direction.
- * @returns Main/cross start offsets and median main/cross gaps.
- */
-function inferFlowLayoutMetrics(
-  container: ItemObject,
-  axes: FlowAxes,
-): FlowMetrics {
-  const containerProp = requireDragSnapshot(container);
-  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
-  if (ordered.length === 0) {
-    return {
-      mainStart: 0,
-      crossStart: 0,
-      mainGap: 0,
-      crossGap: 0,
-      lineCount: 0,
+function createLayoutSnapshot(root: ItemObject): {
+  root: LayoutNode<ItemObject>;
+  byItem: Map<ItemObject, LayoutNode<ItemObject>>;
+} {
+  const byItem = new Map<ItemObject, LayoutNode<ItemObject>>();
+  const visit = (item: ItemObject): LayoutNode<ItemObject> => {
+    const node: LayoutNode<ItemObject> = {
+      value: item,
+      direction: getDirection(item),
+      locked: item.locked,
+      isGhost: item.isGhost,
+      box: requireDragSnapshot(item),
+      children: [],
     };
-  }
-
-  const firstOffset = childRelativeOffset(
-    containerProp,
-    requireDragSnapshot(ordered[0]),
-  );
-  const mainGaps: number[] = [];
-  const lines: Array<{ cross: number; crossSize: number }> = [];
-  let currentLine: { cross: number; crossSize: number } | null = null;
-  let previousOffset: { x: number; y: number } | null = null;
-
-  for (let i = 0; i < ordered.length; i++) {
-    const item = ordered[i];
-    const prop = requireDragSnapshot(item);
-    const offset = childRelativeOffset(containerProp, prop);
-    const startsNewLine =
-      previousOffset != null &&
-      offset[axes.main] < previousOffset[axes.main] - 1;
-    if (!currentLine || startsNewLine) {
-      currentLine = {
-        cross: offset[axes.cross],
-        crossSize: prop[axes.crossSize],
-      };
-      lines.push(currentLine);
-    } else {
-      currentLine.crossSize = Math.max(
-        currentLine.crossSize,
-        prop[axes.crossSize],
-      );
-    }
-
-    const next = ordered[i + 1];
-    if (next) {
-      const nextOffset = childRelativeOffset(
-        containerProp,
-        requireDragSnapshot(next),
-      );
-      const nextStartsNewLine = nextOffset[axes.main] < offset[axes.main] - 1;
-      if (!nextStartsNewLine) {
-        const gap =
-          nextOffset[axes.main] - (offset[axes.main] + prop[axes.mainSize]);
-        if (gap >= 0) mainGaps.push(gap);
-      }
-    }
-    previousOffset = offset;
-  }
-
-  const crossGaps: number[] = [];
-  for (let i = 0; i < lines.length - 1; i++) {
-    const gap = lines[i + 1].cross - (lines[i].cross + lines[i].crossSize);
-    if (gap >= 0) crossGaps.push(gap);
-  }
-
-  return {
-    mainStart: firstOffset[axes.main],
-    crossStart: firstOffset[axes.cross],
-    mainGap: median(mainGaps),
-    crossGap: median(crossGaps),
-    lineCount: lines.length,
+    byItem.set(item, node);
+    node.children = item.dragSnapshotOrderedList.map(visit);
+    return node;
   };
+
+  return { root: visit(root), byItem };
 }
 
-/**
- * Replay flex layout from the frozen snapshot.
- *
- * The dragged item is omitted, and a virtual ghost can be inserted at a
- * candidate index. This is the shared layout engine for rows and columns; only
- * the main/cross axes change.
- *
- * @param container Container whose children are being simulated.
- * @param draggedItem Item excluded from the simulated flow.
- * @param startX Absolute x-coordinate of the container content origin.
- * @param startY Absolute y-coordinate of the container content origin.
- * @param ghost Optional virtual ghost insertion to test.
- * @returns Simulated item positions and the simulated ghost position, if any.
- */
-function flowLayoutPositions(
-  container: ItemObject,
-  draggedItem: ItemObject,
-  startX: number,
-  startY: number,
+function layoutGhostFromItem(
+  byItem: Map<ItemObject, LayoutNode<ItemObject>>,
   ghost?: VirtualGhost,
-): FlowPositionResult {
-  const axes = flowAxes(container);
-  const containerProp = requireDragSnapshot(container);
-  const contentSize = contentBoxSize(containerProp);
-  const ordered = container.dragSnapshotOrderedList.filter((i) => !i.isGhost);
-  const items = ordered.filter((i) => i !== draggedItem);
-  const metrics = inferFlowLayoutMetrics(container, axes);
-  const entries: FlowEntry[] = items.map((item) => {
-    const dimensions = isSubContainer(item)
-      ? virtualDimensions(item, draggedItem, ghost)
-      : requireDragSnapshot(item);
-    return {
-      kind: "item",
-      item,
-      width: dimensions.width,
-      height: dimensions.height,
-    };
-  });
-
-  if (ghost?.container === container) {
-    entries.splice(Math.max(0, Math.min(ghost.index, entries.length)), 0, {
-      kind: "ghost",
-      width: ghost.width,
-      height: ghost.height,
-    });
-  }
-
-  const itemPositions = new Map<ItemObject, { x: number; y: number }>();
-  let ghostPosition: { x: number; y: number } | null = null;
-  const origin = { x: startX, y: startY };
-  const lineMainStart = origin[axes.main] + metrics.mainStart;
-  const lineCrossStart = origin[axes.cross] + metrics.crossStart;
-  const maxMain = origin[axes.main] + contentSize[axes.mainSize];
-  const canWrap = axes.direction === "row" || metrics.lineCount > 1;
-  let cursorMain = lineMainStart;
-  let cursorCross = lineCrossStart;
-  let lineCrossSize = 0;
-
-  for (const entry of entries) {
-    const entryMainSize = entry[axes.mainSize];
-    const entryCrossSize = entry[axes.crossSize];
-    if (
-      canWrap &&
-      cursorMain > lineMainStart + 0.5 &&
-      cursorMain + entryMainSize > maxMain + 0.5
-    ) {
-      cursorMain = lineMainStart;
-      cursorCross += lineCrossSize + metrics.crossGap;
-      lineCrossSize = 0;
-    }
-
-    let position = pointFromAxes(axes, cursorMain, cursorCross);
-    if (entry.kind === "item" && entry.item.locked) {
-      const prop = requireDragSnapshot(entry.item);
-      const rel = childRelativeOffset(containerProp, prop);
-      position = { x: startX + rel.x, y: startY + rel.y };
-      cursorMain = position[axes.main];
-      cursorCross = position[axes.cross];
-    }
-
-    if (entry.kind === "ghost") {
-      ghostPosition = position;
-    } else {
-      itemPositions.set(entry.item, position);
-    }
-
-    cursorMain += entryMainSize + metrics.mainGap;
-    lineCrossSize = Math.max(lineCrossSize, entryCrossSize);
-  }
-
-  return { itemPositions, ghostPosition };
+): LayoutVirtualGhost<ItemObject> | undefined {
+  if (!ghost) return undefined;
+  const container = byItem.get(ghost.container);
+  if (!container) return undefined;
+  return {
+    container,
+    index: ghost.index,
+    width: ghost.width,
+    height: ghost.height,
+  };
 }
 
 /**
@@ -623,6 +322,7 @@ function drawContainerContentBox(
  * @returns Nothing.
  */
 function dumpSnapshotOnce(item: ItemObject, root: ItemObject) {
+  if (!SNAPSHOT_DUMP_TRACE) return;
   if (snapshotDumpedForDrag.has(item)) return;
   snapshotDumpedForDrag.add(item);
 
@@ -654,7 +354,7 @@ function dumpSnapshotOnce(item: ItemObject, root: ItemObject) {
 }
 
 /** Toggle to silence the per-candidate ASCII layout trace in the console. */
-const LAYOUT_TRACE = true;
+const LAYOUT_TRACE = false;
 
 /**
  * Log an ASCII snapshot of the virtual layout that produced one candidate.
@@ -746,7 +446,10 @@ function logCandidateSnapshot(args: {
     const tag = isSubContainer(it) ? "▭" : "▪";
     const layout = layoutByItem.get(it);
     if (layout) {
-      const rel = childRelativeOffset(requireDragSnapshot(args.container), prop);
+      const rel = childRelativeOffset(
+        requireDragSnapshot(args.container),
+        prop,
+      );
       const dx = layout.simulatedPosition.x - layout.measuredPosition.x;
       const dy = layout.simulatedPosition.y - layout.measuredPosition.y;
       lines.push(
@@ -794,69 +497,20 @@ export function virtualDimensions(
   draggedItem: ItemObject,
   ghost?: VirtualGhost,
 ): VirtualDimensions {
-  const axes = flowAxes(container);
-  const containerProp = requireDragSnapshot(container);
-  const items = snapshotItems(container, draggedItem);
-  const flowPositions = flowLayoutPositions(
-    container,
-    draggedItem,
-    0,
-    0,
-    ghost,
+  const snapshot = createLayoutSnapshot(container);
+  const draggedNode = snapshot.byItem.get(draggedItem) ?? {
+    value: draggedItem,
+    direction: getDirection(draggedItem),
+    locked: draggedItem.locked,
+    isGhost: draggedItem.isGhost,
+    box: requireDragSnapshot(draggedItem),
+    children: [],
+  };
+  return layoutVirtualDimensions(
+    snapshot.root,
+    draggedNode,
+    layoutGhostFromItem(snapshot.byItem, ghost),
   );
-  let maxX = 0;
-  let maxY = 0;
-
-  for (const child of items) {
-    const dimensions = isSubContainer(child)
-      ? virtualDimensions(child, draggedItem, ghost)
-      : requireDragSnapshot(child);
-    const rel = childRelativeOffset(containerProp, requireDragSnapshot(child));
-    const measured = { x: rel.x, y: rel.y };
-    const simulated = flowPositions.itemPositions.get(child) ?? measured;
-    maxX = Math.max(maxX, simulated.x + dimensions.width);
-    maxY = Math.max(maxY, simulated.y + dimensions.height);
-  }
-
-  if (ghost?.container === container && flowPositions.ghostPosition) {
-    maxX = Math.max(maxX, flowPositions.ghostPosition.x + ghost.width);
-    maxY = Math.max(maxY, flowPositions.ghostPosition.y + ghost.height);
-  }
-
-  const snapshotSize = {
-    width: containerProp.width,
-    height: containerProp.height,
-  };
-  const virtualSize = {
-    width:
-      containerProp.border.left +
-      containerProp.padding.left +
-      maxX +
-      containerProp.padding.right +
-      containerProp.border.right,
-    height:
-      containerProp.border.top +
-      containerProp.padding.top +
-      maxY +
-      containerProp.padding.bottom +
-      containerProp.border.bottom,
-  };
-
-  if (items.length === 0 && ghost?.container !== container) {
-    return snapshotSize;
-  }
-
-  if (axes.direction === "row") {
-    return {
-      width: snapshotSize.width,
-      height: Math.max(snapshotSize.height, virtualSize.height),
-    };
-  }
-
-  return {
-    width: snapshotSize.width,
-    height: virtualSize.height,
-  };
 }
 
 /**
@@ -886,21 +540,54 @@ export function virtualLayoutRecursive(
   dragCenterX: number,
   dragCenterY: number,
 ): { candidates: DropCandidate[]; endX: number; endY: number } {
+  const snapshot = createLayoutSnapshot(container);
+  const draggedNode = snapshot.byItem.get(draggedItem) ?? {
+    value: draggedItem,
+    direction: getDirection(draggedItem),
+    locked: draggedItem.locked,
+    isGhost: draggedItem.isGhost,
+    box: requireDragSnapshot(draggedItem),
+    children: [],
+  };
+  return virtualLayoutRecursiveFromNode(
+    snapshot.root,
+    startX,
+    startY,
+    draggedNode,
+    dragGhostW,
+    dragGhostH,
+    dragCenterX,
+    dragCenterY,
+  );
+}
+
+function virtualLayoutRecursiveFromNode(
+  containerNode: LayoutNode<ItemObject>,
+  startX: number,
+  startY: number,
+  draggedNode: LayoutNode<ItemObject>,
+  dragGhostW: number,
+  dragGhostH: number,
+  dragCenterX: number,
+  dragCenterY: number,
+): { candidates: DropCandidate[]; endX: number; endY: number } {
+  const container = containerNode.value;
   const axes = flowAxes(container);
   const isColumn = axes.direction === "column";
-  const containerProp = requireDragSnapshot(container);
+  const containerProp = containerNode.box;
   const contentSize = contentBoxSize(containerProp);
   const containerWidth = contentSize.width;
-  const items = snapshotItems(container, draggedItem);
+  const itemNodes = layoutItems(containerNode, draggedNode);
+  const items = itemNodes.map((item) => item.value);
   const flowPositions = flowLayoutPositions(
-    container,
-    draggedItem,
+    containerNode,
+    draggedNode,
     startX,
     startY,
   ).itemPositions;
 
   const candidates: DropCandidate[] = [];
-  const layoutItems: Array<{
+  const layoutDebugItems: Array<{
     item: ItemObject;
     measuredPosition: { x: number; y: number };
     simulatedPosition: { x: number; y: number };
@@ -919,12 +606,12 @@ export function virtualLayoutRecursive(
     fallbackPosition: { x: number; y: number },
   ): DropCandidate => {
     const ghostPosition = flowLayoutPositions(
-      container,
-      draggedItem,
+      containerNode,
+      draggedNode,
       startX,
       startY,
       {
-        container,
+        container: containerNode,
         index,
         width: dragGhostW,
         height: dragGhostH,
@@ -951,38 +638,41 @@ export function virtualLayoutRecursive(
     };
   };
 
-  for (let j = 0; j < items.length; j++) {
-    const item = items[j];
-    const canPlaceCandidate = !item.locked;
-    const prop = requireDragSnapshot(item);
-    const isContainer = isSubContainer(item);
+  for (let j = 0; j < itemNodes.length; j++) {
+    const itemNode = itemNodes[j];
+    const item = itemNode.value;
+    const canPlaceCandidate = !itemNode.locked;
+    const prop = itemNode.box;
+    const isContainer = itemNode.children.length > 0;
     const rel = childRelativeOffset(containerProp, prop);
     const measuredPosition = { x: startX + rel.x, y: startY + rel.y };
-    const simulatedPosition = flowPositions.get(item) ?? measuredPosition;
-    layoutItems.push({ item, measuredPosition, simulatedPosition });
+    const simulatedPosition = flowPositions.get(itemNode) ?? measuredPosition;
+    layoutDebugItems.push({ item, measuredPosition, simulatedPosition });
     drawSnapshotDebug(container, item, measuredPosition, simulatedPosition);
 
     if (canPlaceCandidate) {
       const beforeCandidate = makeCandidate(j, simulatedPosition);
       candidates.push(beforeCandidate);
-      logCandidateSnapshot({
-        container,
-        items,
-        insertIdx: j,
-        isColumn,
-        startX,
-        startY,
-        containerWidth,
-        ghostCenterX: beforeCandidate.ghostCenterX,
-        ghostCenterY: beforeCandidate.ghostCenterY,
-        ghostW: dragGhostW,
-        ghostH: dragGhostH,
-        distance: beforeCandidate.distance,
-        priority: beforeCandidate.priority,
-        dragCenterX,
-        dragCenterY,
-        layoutItems,
-      });
+      if (LAYOUT_TRACE) {
+        logCandidateSnapshot({
+          container,
+          items,
+          insertIdx: j,
+          isColumn,
+          startX,
+          startY,
+          containerWidth,
+          ghostCenterX: beforeCandidate.ghostCenterX,
+          ghostCenterY: beforeCandidate.ghostCenterY,
+          ghostW: dragGhostW,
+          ghostH: dragGhostH,
+          distance: beforeCandidate.distance,
+          priority: beforeCandidate.priority,
+          dragCenterX,
+          dragCenterY,
+          layoutItems: layoutDebugItems,
+        });
+      }
       container.addDebugRect(
         beforeCandidate.ghostCenterX - dragGhostW / 2,
         beforeCandidate.ghostCenterY - dragGhostH / 2,
@@ -1002,11 +692,11 @@ export function virtualLayoutRecursive(
         x: simulatedPosition.x + prop.border.left + prop.padding.left,
         y: simulatedPosition.y + prop.border.top + prop.padding.top,
       };
-      const sub = virtualLayoutRecursive(
-        item,
+      const sub = virtualLayoutRecursiveFromNode(
+        itemNode,
         childOrigin.x,
         childOrigin.y,
-        draggedItem,
+        draggedNode,
         dragGhostW,
         dragGhostH,
         dragCenterX,
@@ -1062,30 +752,31 @@ export function virtualLayoutRecursive(
     }
 
     if (canPlaceCandidate) {
-      const fallbackMain =
-        simulatedPosition[axes.main] + prop[axes.mainSize];
+      const fallbackMain = simulatedPosition[axes.main] + prop[axes.mainSize];
       const fallbackCross = simulatedPosition[axes.cross];
       const fallbackPosition = pointFromAxes(axes, fallbackMain, fallbackCross);
       const afterCandidate = makeCandidate(j + 1, fallbackPosition);
       candidates.push(afterCandidate);
-      logCandidateSnapshot({
-        container,
-        items,
-        insertIdx: j + 1,
-        isColumn,
-        startX,
-        startY,
-        containerWidth,
-        ghostCenterX: afterCandidate.ghostCenterX,
-        ghostCenterY: afterCandidate.ghostCenterY,
-        ghostW: dragGhostW,
-        ghostH: dragGhostH,
-        distance: afterCandidate.distance,
-        priority: afterCandidate.priority,
-        dragCenterX,
-        dragCenterY,
-        layoutItems,
-      });
+      if (LAYOUT_TRACE) {
+        logCandidateSnapshot({
+          container,
+          items,
+          insertIdx: j + 1,
+          isColumn,
+          startX,
+          startY,
+          containerWidth,
+          ghostCenterX: afterCandidate.ghostCenterX,
+          ghostCenterY: afterCandidate.ghostCenterY,
+          ghostW: dragGhostW,
+          ghostH: dragGhostH,
+          distance: afterCandidate.distance,
+          priority: afterCandidate.priority,
+          dragCenterX,
+          dragCenterY,
+          layoutItems: layoutDebugItems,
+        });
+      }
       container.addDebugRect(
         afterCandidate.ghostCenterX - dragGhostW / 2,
         afterCandidate.ghostCenterY - dragGhostH / 2,
@@ -1371,10 +1062,7 @@ export function determineDropTarget(
  * @param draggedItem Item currently being dragged.
  * @returns Nothing.
  */
-export function debugDropTargetTree(
-  node: ItemObject,
-  draggedItem: ItemObject,
-) {
+export function debugDropTargetTree(node: ItemObject, draggedItem: ItemObject) {
   const items = node.itemOrderedList.filter(
     (i) => i !== draggedItem && !i.isGhost,
   );

--- a/assets/snapsort/core/src/item.ts
+++ b/assets/snapsort/core/src/item.ts
@@ -1,8 +1,13 @@
-import { BaseObject, ElementObject } from "@snap-engine/core";
+import { BaseObject, ElementObject, cloneDomProperty } from "@snap-engine/core";
 import type { ItemContainer } from "./container";
 import { RectCollider, PointCollider } from "@snap-engine/core/collision";
-import type { dragStartProp, dragProp, dragEndProp } from "@snap-engine/core";
-import { determineDropTarget } from "./drop_target";
+import type {
+  dragStartProp,
+  dragProp,
+  dragEndProp,
+  DomProperty,
+} from "@snap-engine/core";
+import { determineDropTarget, resetDropSnapshotDebugDump } from "./drop_target";
 
 /**
  * How much to enlarge an item's hitbox while it is being dragged. The hitbox
@@ -22,6 +27,8 @@ export class ItemObject extends ElementObject {
 
   #dragOffsetX: number = 0;
   #dragOffsetY: number = 0;
+  #dragSnapshot: DomProperty | null = null;
+  #dragSnapshotOrderedList: ItemObject[] = [];
 
   #itemOrderedList: ItemObject[] = []; // Wrapper around children to maintain their order in the DOM
 
@@ -132,6 +139,14 @@ export class ItemObject extends ElementObject {
     return this.#itemOrderedList;
   }
 
+  get dragSnapshot(): DomProperty | null {
+    return this.#dragSnapshot;
+  }
+
+  get dragSnapshotOrderedList(): ItemObject[] {
+    return this.#dragSnapshotOrderedList;
+  }
+
   get hitbox(): RectCollider {
     return this.#hitbox;
   }
@@ -223,6 +238,30 @@ export class ItemObject extends ElementObject {
       if (child instanceof ItemObject) {
         child.#updateState(root, depth + 1);
       }
+    }
+  }
+
+  #captureDragSnapshotTree() {
+    this.#dragSnapshot = cloneDomProperty(this.getDomProperty("READ_1"));
+    this.#dragSnapshotOrderedList = this.#itemOrderedList.slice();
+    for (const child of this.#dragSnapshotOrderedList) {
+      child.#captureDragSnapshotTree();
+    }
+  }
+
+  #clearDragSnapshotTree(visited: Set<ItemObject> = new Set()) {
+    if (visited.has(this)) return;
+    visited.add(this);
+
+    const childrenToClear = new Set([
+      ...this.#dragSnapshotOrderedList,
+      ...this.#itemOrderedList,
+    ]);
+    this.#dragSnapshot = null;
+    this.#dragSnapshotOrderedList = [];
+
+    for (const child of childrenToClear) {
+      child.#clearDragSnapshotTree(visited);
     }
   }
 
@@ -374,6 +413,41 @@ export class ItemObject extends ElementObject {
     }
   }
 
+  #liveIndexFromSnapshotIndex(
+    container: ItemObject,
+    snapshotIndex: number,
+    draggedItem: ItemObject,
+  ): number {
+    const snapshotItems = container.#dragSnapshotOrderedList.filter(
+      (i) => i !== draggedItem && !i.isGhost,
+    );
+    const ghostItem = this.#rootContainer?.ghostItem ?? null;
+    const liveItems = container.#itemOrderedList.filter(
+      (i) => i !== draggedItem && i !== ghostItem,
+    );
+    const clampedIndex = Math.max(
+      0,
+      Math.min(snapshotIndex, snapshotItems.length),
+    );
+    const beforeItem = snapshotItems[clampedIndex] ?? null;
+    if (!beforeItem) return liveItems.length;
+
+    const liveIndex = liveItems.indexOf(beforeItem);
+    return liveIndex === -1 ? liveItems.length : liveIndex;
+  }
+
+  #ghostInsertionPosition(
+    ghostItem: ItemObject | null,
+  ): { index: number; container: ItemObject | null } | null {
+    if (!ghostItem?.parent) return null;
+
+    const container = ghostItem.parent as ItemObject;
+    const index = container.#itemOrderedList.indexOf(ghostItem);
+    if (index === -1) return null;
+
+    return { container, index };
+  }
+
   /**
    * Create or remove a ghost element at the specified container and index.
    * A null container means the ghost element should be removed.
@@ -411,19 +485,18 @@ export class ItemObject extends ElementObject {
       const ghostElement = document.createElement("div");
       ghostElement.id = "spacer";
 
-      ghostElement.style.width = original.getDomProperty("READ_1").width + "px";
-      ghostElement.style.height =
-        original.getDomProperty("READ_1").height + "px";
-      // ghostElement.style.margin = "" + original.getDomProperty("READ_1").margin;
+      const origProp = original.dragSnapshot ?? original.getDomProperty("READ_1");
+      ghostElement.style.width = origProp.width + "px";
+      ghostElement.style.height = origProp.height + "px";
+      ghostElement.style.margin = `${origProp.margin.top}px ${origProp.margin.right}px ${origProp.margin.bottom}px ${origProp.margin.left}px`;
       // ghostElement.style.padding = "" + original.getDomProperty("READ_1").padding;
-      // ghostElement.style.boxSizing = "" + original.getDomProperty("READ_1").boxSizing;
+      ghostElement.style.boxSizing = "border-box";
       ghostElement.classList.add("ghost");
 
-      ghostItem = new ItemObject(this.engine, null, null, true);
+      ghostItem = new ItemObject(this.engine, null, true);
       ghostItem.element = ghostElement;
 
       // Set hitbox so the collision engine can detect overlaps with the ghost
-      const origProp = original.getDomProperty("READ_1");
       ghostItem.hitbox.local.width = origProp.width;
       ghostItem.hitbox.local.height = origProp.height;
       ghostItem.centerPoint.local.x = origProp.width / 2;
@@ -468,24 +541,32 @@ export class ItemObject extends ElementObject {
     // Compare against the ghost's current position, not the dragged item's (which is removed from the list during drag)
     // In other words, check what the previous drop target was based on where the ghost is.
     const ghostItem = this.#rootContainer?.ghostItem;
-    const ghostSource = ghostItem?.getIndexAndContainer();
+    const ghostSource = this.#ghostInsertionPosition(ghostItem ?? null);
+    const targetIndex =
+      target?.container != null
+        ? this.#liveIndexFromSnapshotIndex(
+            target.container,
+            target.index,
+            item,
+          )
+        : -1;
     console.debug(
-      `[updateDropTarget] item=${item.gid} target=${target ? `${target.container.gid}[${target.index}]` : "null"} ghostPos=${ghostSource?.container ? `${(ghostSource.container as unknown as ItemObject).gid}[${ghostSource.index}]` : "null"}`,
+      `[updateDropTarget] item=${item.gid} target=${target ? `${target.container.gid}[snapshot:${target.index} live:${targetIndex}]` : "null"} ghostPos=${ghostSource?.container ? `${(ghostSource.container as unknown as ItemObject).gid}[${ghostSource.index}]` : "null"}`,
     );
     if (target?.container && ghostSource?.container) {
       const sameContainer = target.container === ghostSource.container;
-      const sameIndex = target.index === ghostSource.index;
+      const sameIndex = targetIndex === ghostSource.index;
       console.debug(
-        `[updateDropTarget]   sameContainer=${sameContainer} sameIndex=${sameIndex} (${target.index}===${ghostSource.index})`,
+        `[updateDropTarget]   sameContainer=${sameContainer} sameIndex=${sameIndex} (${targetIndex}===${ghostSource.index})`,
       );
       if (!sameContainer || !sameIndex) {
         console.debug(
-          `[updateDropTarget]   >>> MOVING ghost to ${target.container.gid}[${target.index}]`,
+          `[updateDropTarget]   >>> MOVING ghost to ${target.container.gid}[${targetIndex}]`,
         );
         this.#updateGhostElement(
           item,
           target.container as unknown as ItemContainer,
-          target.index,
+          targetIndex,
         );
       } else {
         console.debug(`[updateDropTarget]   SKIP: ghost already at target`);
@@ -495,7 +576,7 @@ export class ItemObject extends ElementObject {
       this.#updateGhostElement(
         item,
         target.container as unknown as ItemContainer,
-        target.index,
+        targetIndex,
       );
     } else {
       console.debug(`[updateDropTarget]   SKIP: no target`);
@@ -507,6 +588,8 @@ export class ItemObject extends ElementObject {
     console.debug(`[dragStart] item=${this.gid}`);
     // Set the root container for all items, and queue READ to update the state of all containers and items.
     this.#findRootContainer();
+    const root = (this.#rootContainer as unknown as ItemObject) ?? this;
+    resetDropSnapshotDebugDump(this);
     // Get the current index of the item in its container.
     const { index: currentIndex, container: currentContainer } =
       this.getIndexAndContainer();
@@ -524,6 +607,7 @@ export class ItemObject extends ElementObject {
         console.debug(
           `[dragStart READ_1] offset=(${this.#dragOffsetX}, ${this.#dragOffsetY}) start=(${prop.start.x}, ${prop.start.y}) transform=(${this.transform.x}, ${this.transform.y})`,
         );
+        root.#captureDragSnapshotTree();
       },
       `drag-start-offset-${this.gid}`,
     );
@@ -549,12 +633,19 @@ export class ItemObject extends ElementObject {
         `[dragStart] after removing dragged item, orderedList=[${(currentContainer as unknown as ItemObject).#itemOrderedList.map((i) => i.gid).join(", ")}]`,
       );
 
+      const rootSnapshot = root.dragSnapshot;
+      const hoistOffsetX = rootSnapshot
+        ? -(rootSnapshot.border.left + rootSnapshot.padding.left)
+        : 0;
+      const hoistOffsetY = rootSnapshot
+        ? -(rootSnapshot.border.top + rootSnapshot.padding.top)
+        : 0;
       this.style = {
         cursor: "grabbing",
         position: "absolute",
         zIndex: "1000",
-        top: "0px",
-        left: "0px",
+        top: `${hoistOffsetY}px`,
+        left: `${hoistOffsetX}px`,
       };
       this.#hoistElementToRoot();
       this.transformMode = "origin";
@@ -598,6 +689,7 @@ export class ItemObject extends ElementObject {
   }
 
   dragEnd(_: dragEndProp) {
+    const root = (this.#rootContainer as unknown as ItemObject) ?? this;
     this.requestWrite(true, () => {
       // Get ghost's current position — this is where the item should land
       const ghostItem = this.#rootContainer?.ghostItem;
@@ -639,6 +731,8 @@ export class ItemObject extends ElementObject {
       this.#hitbox.local.y = 0;
       this.writeDom();
       this.writeTransform();
+      root.#clearDragSnapshotTree();
+      resetDropSnapshotDebugDump(this);
     });
   }
 

--- a/assets/snapsort/core/src/item.ts
+++ b/assets/snapsort/core/src/item.ts
@@ -16,6 +16,13 @@ import { AnimationObject } from "@snap-engine/core/animation";
  */
 const DRAG_HITBOX_SCALE = 4;
 const MIN_FLIP_DISTANCE = 0.5;
+const DEBUG_LOGS = false;
+
+function debugLog(...args: unknown[]) {
+  if (DEBUG_LOGS) {
+    console.debug(...args);
+  }
+}
 
 interface FlipSnapshot {
   item: ItemObject;
@@ -94,16 +101,16 @@ export class ItemObject extends ElementObject {
 
   getIndexAndContainer(): { index: number; container: ItemObject | null } {
     if (!this.parent) {
-      console.debug(
-        `[getIndexAndContainer] ${this.gid} has no parent → index=-1`,
-      );
+      DEBUG_LOGS &&
+        debugLog(`[getIndexAndContainer] ${this.gid} has no parent → index=-1`);
       return { index: -1, container: null };
     }
     const parentContainer = this.parent as unknown as ItemObject;
     const idx = parentContainer.#itemOrderedList.indexOf(this);
-    console.debug(
-      `[getIndexAndContainer] ${this.gid} → container=${parentContainer.gid}, index=${idx}, orderedList=[${parentContainer.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[getIndexAndContainer] ${this.gid} → container=${parentContainer.gid}, index=${idx}, orderedList=[${parentContainer.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+      );
     return { index: idx, container: parentContainer };
   }
 
@@ -427,7 +434,10 @@ export class ItemObject extends ElementObject {
 
       const dx = first.x - last.x;
       const dy = first.y - last.y;
-      if (Math.abs(dx) < MIN_FLIP_DISTANCE && Math.abs(dy) < MIN_FLIP_DISTANCE) {
+      if (
+        Math.abs(dx) < MIN_FLIP_DISTANCE &&
+        Math.abs(dy) < MIN_FLIP_DISTANCE
+      ) {
         continue;
       }
 
@@ -569,30 +579,33 @@ export class ItemObject extends ElementObject {
     const sourceIndex = sourceContainer
       ? sourceContainer.#itemOrderedList.indexOf(item)
       : -1;
-    console.debug(
-      `[moveItemToContainer] item=${item.gid} from=${sourceContainer?.gid ?? "null"}[${sourceIndex}] to=${(container as unknown as ItemObject).gid}[${index}] updateDom=${updateDom}`,
-    );
-    console.debug(
-      `[moveItemToContainer]   source orderedList=[${sourceContainer ? sourceContainer.#itemOrderedList.map((i) => i.gid).join(", ") : "N/A"}]`,
-    );
-    console.debug(
-      `[moveItemToContainer]   target orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[moveItemToContainer] item=${item.gid} from=${sourceContainer?.gid ?? "null"}[${sourceIndex}] to=${(container as unknown as ItemObject).gid}[${index}] updateDom=${updateDom}`,
+      );
+    DEBUG_LOGS &&
+      debugLog(
+        `[moveItemToContainer]   source orderedList=[${sourceContainer ? sourceContainer.#itemOrderedList.map((i) => i.gid).join(", ") : "N/A"}]`,
+      );
+    DEBUG_LOGS &&
+      debugLog(
+        `[moveItemToContainer]   target orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+      );
     // If the source and target container is the same, we must adjust the index
     // to account for the removal of the item from its original position.
     if (item.parent === container) {
       // If the source and target index is the same, no need to move.
       if (container.#itemOrderedList.indexOf(item) === index) {
-        console.debug(
-          `[moveItemToContainer]   SKIP: same container, same index`,
-        );
+        DEBUG_LOGS &&
+          debugLog(`[moveItemToContainer]   SKIP: same container, same index`);
         return;
       }
       const currentIndex = container.#itemOrderedList.indexOf(item);
       if (currentIndex !== -1 && currentIndex < index) {
-        console.debug(
-          `[moveItemToContainer]   adjusting index: ${index} → ${index - 1} (same container, current=${currentIndex} < target=${index})`,
-        );
+        DEBUG_LOGS &&
+          debugLog(
+            `[moveItemToContainer]   adjusting index: ${index} → ${index - 1} (same container, current=${currentIndex} < target=${index})`,
+          );
         index -= 1;
       }
     }
@@ -601,9 +614,10 @@ export class ItemObject extends ElementObject {
     // so we don't want to remove it from the DOM.
     this.removeItemFrom(item.container, item, false);
     this.insertItemAt(container, item, index);
-    console.debug(
-      `[moveItemToContainer]   DONE. target orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[moveItemToContainer]   DONE. target orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+      );
   }
 
   /**
@@ -617,32 +631,37 @@ export class ItemObject extends ElementObject {
    * @returns Nothing.
    */
   insertItemAt(container: ItemContainer, item: ItemObject, index: number) {
-    console.debug(
-      `[insertItemAt] item=${item.gid} into container=${(container as unknown as ItemObject).gid} at index=${index}`,
-    );
-    console.debug(
-      `[insertItemAt]   BEFORE orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}] (len=${container.#itemOrderedList.length})`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[insertItemAt] item=${item.gid} into container=${(container as unknown as ItemObject).gid} at index=${index}`,
+      );
+    DEBUG_LOGS &&
+      debugLog(
+        `[insertItemAt]   BEFORE orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}] (len=${container.#itemOrderedList.length})`,
+      );
     (container as unknown as ItemObject).appendChild(item);
     if (index >= container.#itemOrderedList.length) {
-      console.debug(
-        `[insertItemAt]   index ${index} >= len ${container.#itemOrderedList.length}, appending`,
-      );
+      DEBUG_LOGS &&
+        debugLog(
+          `[insertItemAt]   index ${index} >= len ${container.#itemOrderedList.length}, appending`,
+        );
       container.#itemOrderedList.push(item);
     } else {
-      console.debug(`[insertItemAt]   splicing at index ${index}`);
+      DEBUG_LOGS && debugLog(`[insertItemAt]   splicing at index ${index}`);
       container.#itemOrderedList.splice(index, 0, item);
     }
     const itemAfterIndex =
       index >= container.#itemOrderedList.length - 1
         ? null
         : container.#itemOrderedList[index + 1].element;
-    console.debug(
-      `[insertItemAt]   AFTER orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-    );
-    console.debug(
-      `[insertItemAt]   DOM insertBefore: item.element=${item.element?.id ?? "null"}, before=${itemAfterIndex ? (itemAfterIndex as any).element?.id ?? itemAfterIndex.gid : "null (append)"}`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[insertItemAt]   AFTER orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+      );
+    DEBUG_LOGS &&
+      debugLog(
+        `[insertItemAt]   DOM insertBefore: item.element=${item.element?.id ?? "null"}, before=${itemAfterIndex ? (itemAfterIndex as any).element?.id ?? itemAfterIndex.gid : "null (append)"}`,
+      );
     container.element?.insertBefore(item.element!, itemAfterIndex);
   }
 
@@ -659,19 +678,22 @@ export class ItemObject extends ElementObject {
     item: ItemObject,
     deleteElement: boolean = true,
   ) {
-    console.debug(
-      `[removeItemFrom] item=${item.gid} from container=${(container as unknown as ItemObject).gid} deleteElement=${deleteElement}`,
-    );
-    console.debug(
-      `[removeItemFrom]   BEFORE orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[removeItemFrom] item=${item.gid} from container=${(container as unknown as ItemObject).gid} deleteElement=${deleteElement}`,
+      );
+    DEBUG_LOGS &&
+      debugLog(
+        `[removeItemFrom]   BEFORE orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+      );
     container.removeChild(item);
     container.#itemOrderedList = container.#itemOrderedList.filter(
       (i) => i !== item,
     );
-    console.debug(
-      `[removeItemFrom]   AFTER orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[removeItemFrom]   AFTER orderedList=[${container.#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+      );
     if (deleteElement) {
       item.element?.remove();
     }
@@ -744,15 +766,17 @@ export class ItemObject extends ElementObject {
     index: number,
   ) {
     let ghostItem = this.#rootContainer?.ghostItem;
-    console.debug(
-      `[updateGhostElement] original=${original.gid} container=${container ? (container as unknown as ItemObject).gid : "null"} index=${index} existingGhost=${ghostItem ? ghostItem.gid : "none"}`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[updateGhostElement] original=${original.gid} container=${container ? (container as unknown as ItemObject).gid : "null"} index=${index} existingGhost=${ghostItem ? ghostItem.gid : "none"}`,
+      );
 
     if (container === null) {
       if (ghostItem) {
-        console.debug(
-          `[updateGhostElement] removing ghost ${ghostItem.gid} from ${(ghostItem.container as unknown as ItemObject)?.gid}`,
-        );
+        DEBUG_LOGS &&
+          debugLog(
+            `[updateGhostElement] removing ghost ${ghostItem.gid} from ${(ghostItem.container as unknown as ItemObject)?.gid}`,
+          );
         // Remove the ghost item and element from the root container.
         this.removeItemFrom(ghostItem.container, ghostItem);
         ghostItem.destroy();
@@ -763,12 +787,13 @@ export class ItemObject extends ElementObject {
     // If ghost element already exists, use that instead of creating a new one.
     // Otherwise, create a new ghost element
     if (!ghostItem) {
-      console.debug(`[updateGhostElement] creating new ghost element`);
+      DEBUG_LOGS && debugLog(`[updateGhostElement] creating new ghost element`);
 
       const ghostElement = document.createElement("div");
       ghostElement.id = "spacer";
 
-      const origProp = original.dragSnapshot ?? original.getDomProperty("READ_1");
+      const origProp =
+        original.dragSnapshot ?? original.getDomProperty("READ_1");
       ghostElement.style.width = origProp.width + "px";
       ghostElement.style.height = origProp.height + "px";
       ghostElement.style.margin = `${origProp.margin.top}px ${origProp.margin.right}px ${origProp.margin.bottom}px ${origProp.margin.left}px`;
@@ -789,20 +814,21 @@ export class ItemObject extends ElementObject {
     const moveGhost = () => {
       // Remove ghost from its current container before re-inserting at the new position
       if (ghostItem.parent) {
-        console.debug(
-          `[updateGhostElement] removing ghost from current container=${(ghostItem.container as unknown as ItemObject)?.gid}`,
-        );
+        DEBUG_LOGS &&
+          debugLog(
+            `[updateGhostElement] removing ghost from current container=${(ghostItem.container as unknown as ItemObject)?.gid}`,
+          );
         this.removeItemFrom(ghostItem.container, ghostItem, false);
       } else {
-        console.debug(
-          `[updateGhostElement] ghost has no parent, skipping remove`,
-        );
+        DEBUG_LOGS &&
+          debugLog(`[updateGhostElement] ghost has no parent, skipping remove`);
       }
       // Insert the ghost item at the new position in the DOM and item list.
       // This also sets the ghost item's container to the new container.
-      console.debug(
-        `[updateGhostElement] inserting ghost at container=${(container as unknown as ItemObject).gid} index=${index}`,
-      );
+      DEBUG_LOGS &&
+        debugLog(
+          `[updateGhostElement] inserting ghost at container=${(container as unknown as ItemObject).gid} index=${index}`,
+        );
       this.insertItemAt(container, ghostItem, index);
     };
 
@@ -839,9 +865,10 @@ export class ItemObject extends ElementObject {
     // the engine scheduler as built-in debounce/coalescing support for input
     // updates that depend on earlier READ/WRITE phases.
     if (!root.#hasDragSnapshotTree() || !item.#dragSnapshot) {
-      console.debug(
-        `[updateDropTarget] SKIP: waiting for drag snapshot root=${root.gid} item=${item.gid}`,
-      );
+      DEBUG_LOGS &&
+        debugLog(
+          `[updateDropTarget] SKIP: waiting for drag snapshot root=${root.gid} item=${item.gid}`,
+        );
       return;
     }
 
@@ -852,48 +879,48 @@ export class ItemObject extends ElementObject {
     const ghostSource = this.#ghostInsertionPosition(ghostItem ?? null);
     const targetIndex =
       target?.container != null
-        ? this.#liveIndexFromSnapshotIndex(
-            target.container,
-            target.index,
-            item,
-          )
+        ? this.#liveIndexFromSnapshotIndex(target.container, target.index, item)
         : -1;
-    console.debug(
-      `[updateDropTarget] item=${item.gid} target=${target ? `${target.container.gid}[snapshot:${target.index} live:${targetIndex}]` : "null"} ghostPos=${ghostSource?.container ? `${(ghostSource.container as unknown as ItemObject).gid}[${ghostSource.index}]` : "null"}`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[updateDropTarget] item=${item.gid} target=${target ? `${target.container.gid}[snapshot:${target.index} live:${targetIndex}]` : "null"} ghostPos=${ghostSource?.container ? `${(ghostSource.container as unknown as ItemObject).gid}[${ghostSource.index}]` : "null"}`,
+      );
     if (target?.container && ghostSource?.container) {
       const sameContainer = target.container === ghostSource.container;
       const sameIndex = targetIndex === ghostSource.index;
-      console.debug(
-        `[updateDropTarget]   sameContainer=${sameContainer} sameIndex=${sameIndex} (${targetIndex}===${ghostSource.index})`,
-      );
-      if (!sameContainer || !sameIndex) {
-        console.debug(
-          `[updateDropTarget]   >>> MOVING ghost to ${target.container.gid}[${targetIndex}]`,
+      DEBUG_LOGS &&
+        debugLog(
+          `[updateDropTarget]   sameContainer=${sameContainer} sameIndex=${sameIndex} (${targetIndex}===${ghostSource.index})`,
         );
+      if (!sameContainer || !sameIndex) {
+        DEBUG_LOGS &&
+          debugLog(
+            `[updateDropTarget]   >>> MOVING ghost to ${target.container.gid}[${targetIndex}]`,
+          );
         this.#updateGhostElement(
           item,
           target.container as unknown as ItemContainer,
           targetIndex,
         );
       } else {
-        console.debug(`[updateDropTarget]   SKIP: ghost already at target`);
+        DEBUG_LOGS &&
+          debugLog(`[updateDropTarget]   SKIP: ghost already at target`);
       }
     } else if (target?.container) {
-      console.debug(`[updateDropTarget]   >>> PLACING initial ghost`);
+      DEBUG_LOGS && debugLog(`[updateDropTarget]   >>> PLACING initial ghost`);
       this.#updateGhostElement(
         item,
         target.container as unknown as ItemContainer,
         targetIndex,
       );
     } else {
-      console.debug(`[updateDropTarget]   SKIP: no target`);
+      DEBUG_LOGS && debugLog(`[updateDropTarget]   SKIP: no target`);
     }
   }
 
   dragStart(prop: dragStartProp) {
     if (this.#locked) return;
-    console.debug(`[dragStart] item=${this.gid}`);
+    DEBUG_LOGS && debugLog(`[dragStart] item=${this.gid}`);
     // Set the root container for all items, and queue READ to update the state of all containers and items.
     this.#findRootContainer();
     const root = (this.#rootContainer as unknown as ItemObject) ?? this;
@@ -901,9 +928,10 @@ export class ItemObject extends ElementObject {
     // Get the current index of the item in its container.
     const { index: currentIndex, container: currentContainer } =
       this.getIndexAndContainer();
-    console.debug(
-      `[dragStart] currentIndex=${currentIndex} currentContainer=${currentContainer?.gid ?? "null"}`,
-    );
+    DEBUG_LOGS &&
+      debugLog(
+        `[dragStart] currentIndex=${currentIndex} currentContainer=${currentContainer?.gid ?? "null"}`,
+      );
     // Compute the drag offset in READ_1, after DOM positions are read but before any WRITE_1
     // callbacks (including drag events). This prevents race conditions where drag events
     // modify this.transform before the offset is calculated.
@@ -912,18 +940,20 @@ export class ItemObject extends ElementObject {
       () => {
         this.#dragOffsetX = prop.start.x - this.transform.x;
         this.#dragOffsetY = prop.start.y - this.transform.y;
-        console.debug(
-          `[dragStart READ_1] offset=(${this.#dragOffsetX}, ${this.#dragOffsetY}) start=(${prop.start.x}, ${prop.start.y}) transform=(${this.transform.x}, ${this.transform.y})`,
-        );
+        DEBUG_LOGS &&
+          debugLog(
+            `[dragStart READ_1] offset=(${this.#dragOffsetX}, ${this.#dragOffsetY}) start=(${prop.start.x}, ${prop.start.y}) transform=(${this.transform.x}, ${this.transform.y})`,
+          );
         root.#captureDragSnapshotTree();
       },
       `drag-start-offset-${this.gid}`,
     );
 
     this.queueUpdate("WRITE_1", () => {
-      console.debug(
-        `[dragStart WRITE_1 callback] placing ghost at container=${currentContainer?.gid ?? "null"} index=${currentIndex}`,
-      );
+      DEBUG_LOGS &&
+        debugLog(
+          `[dragStart WRITE_1 callback] placing ghost at container=${currentContainer?.gid ?? "null"} index=${currentIndex}`,
+        );
 
       this.#updateGhostElement(
         this,
@@ -937,9 +967,10 @@ export class ItemObject extends ElementObject {
         this,
         false,
       );
-      console.debug(
-        `[dragStart] after removing dragged item, orderedList=[${(currentContainer as unknown as ItemObject).#itemOrderedList.map((i) => i.gid).join(", ")}]`,
-      );
+      DEBUG_LOGS &&
+        debugLog(
+          `[dragStart] after removing dragged item, orderedList=[${(currentContainer as unknown as ItemObject).#itemOrderedList.map((i) => i.gid).join(", ")}]`,
+        );
 
       const rootSnapshot = root.dragSnapshot;
       const hoistOffsetX = rootSnapshot
@@ -1002,9 +1033,10 @@ export class ItemObject extends ElementObject {
       // Get ghost's current position — this is where the item should land
       const ghostItem = this.#rootContainer?.ghostItem;
       const ghostPos = ghostItem?.getIndexAndContainer();
-      console.debug(
-        `[dragEnd] item=${this.gid} ghostPos=${ghostPos?.container ? `${(ghostPos.container as unknown as ItemObject).gid}[${ghostPos.index}]` : "null"}`,
-      );
+      DEBUG_LOGS &&
+        debugLog(
+          `[dragEnd] item=${this.gid} ghostPos=${ghostPos?.container ? `${(ghostPos.container as unknown as ItemObject).gid}[${ghostPos.index}]` : "null"}`,
+        );
 
       // Remove the ghost first
       this.#updateGhostElement(this, null, -1);
@@ -1016,9 +1048,10 @@ export class ItemObject extends ElementObject {
           this,
           ghostPos.index,
         );
-        console.debug(
-          `[dragEnd] re-inserted item at ${(ghostPos.container as unknown as ItemObject).gid}[${ghostPos.index}]`,
-        );
+        DEBUG_LOGS &&
+          debugLog(
+            `[dragEnd] re-inserted item at ${(ghostPos.container as unknown as ItemObject).gid}[${ghostPos.index}]`,
+          );
       }
 
       this.style = {

--- a/assets/snapsort/core/src/item.ts
+++ b/assets/snapsort/core/src/item.ts
@@ -296,6 +296,27 @@ export class ItemObject extends ElementObject {
   }
 
   /**
+   * Check whether every item in the frozen drag tree has a snapshot.
+   *
+   * A drag event can arrive before the drag-start READ phase has captured the
+   * snapshot tree. Drop prediction should skip that frame instead of falling
+   * back to live DOM geometry.
+   *
+   * @param visited Items already checked during this traversal.
+   * @returns True when this item and all frozen descendants have snapshots.
+   */
+  #hasDragSnapshotTree(visited: Set<ItemObject> = new Set()): boolean {
+    if (visited.has(this)) return true;
+    visited.add(this);
+
+    if (!this.#dragSnapshot) return false;
+
+    return this.#dragSnapshotOrderedList.every((child) =>
+      child.#hasDragSnapshotTree(visited),
+    );
+  }
+
+  /**
    * Temporarily move the DOM element of an item to the root container during dragging,
    * so it can be positioned absolutely within the root container without affecting the
    * layout of its original container.
@@ -604,6 +625,16 @@ export class ItemObject extends ElementObject {
    */
   updateDropTarget(item: ItemObject) {
     const root = (this.#rootContainer as unknown as ItemObject) ?? this;
+    // Defensive guard for a drag-start/drag race: the deeper fix should live in
+    // the engine scheduler as built-in debounce/coalescing support for input
+    // updates that depend on earlier READ/WRITE phases.
+    if (!root.#hasDragSnapshotTree() || !item.#dragSnapshot) {
+      console.debug(
+        `[updateDropTarget] SKIP: waiting for drag snapshot root=${root.gid} item=${item.gid}`,
+      );
+      return;
+    }
+
     const target = determineDropTarget(item, root);
     // Compare against the ghost's current position, not the dragged item's (which is removed from the list during drag)
     // In other words, check what the previous drop target was based on where the ghost is.

--- a/assets/snapsort/core/src/item.ts
+++ b/assets/snapsort/core/src/item.ts
@@ -157,6 +157,8 @@ export class ItemObject extends ElementObject {
 
   /**
    * Return this item's children sorted by their DOM order.
+   *
+   * @returns Child objects ordered by their current element order in the DOM.
    */
   childrenInDomOrder(): BaseObject[] {
     return this.children.slice().sort((a, b) => {
@@ -217,6 +219,13 @@ export class ItemObject extends ElementObject {
     }
   }
 
+  /**
+   * Walk up to the root container and refresh the SnapSort tree state.
+   *
+   * The root queues the initial DOM read used by drag-start snapshot capture.
+   *
+   * @returns Nothing.
+   */
   #findRootContainer() {
     if (this.parent == null) {
       this.#updateState(this as unknown as ItemContainer);
@@ -227,6 +236,13 @@ export class ItemObject extends ElementObject {
     }
   }
 
+  /**
+   * Refresh root/depth metadata and live child ordering for this subtree.
+   *
+   * @param root Root container that owns the active SnapSort tree.
+   * @param depth Nesting depth of this item within the root tree.
+   * @returns Nothing.
+   */
   #updateState(root: ItemContainer | null, depth: number = 0) {
     // Set root container and depth
     this.#rootContainer = root;
@@ -241,6 +257,14 @@ export class ItemObject extends ElementObject {
     }
   }
 
+  /**
+   * Capture frozen DOM geometry and child order for this subtree.
+   *
+   * The drop algorithm reads this snapshot for the full drag so live ghost DOM
+   * movement cannot perturb candidate prediction.
+   *
+   * @returns Nothing.
+   */
   #captureDragSnapshotTree() {
     this.#dragSnapshot = cloneDomProperty(this.getDomProperty("READ_1"));
     this.#dragSnapshotOrderedList = this.#itemOrderedList.slice();
@@ -249,6 +273,12 @@ export class ItemObject extends ElementObject {
     }
   }
 
+  /**
+   * Clear frozen drag snapshots from this subtree after drag end.
+   *
+   * @param visited Items already cleared during this traversal.
+   * @returns Nothing.
+   */
   #clearDragSnapshotTree(visited: Set<ItemObject> = new Set()) {
     if (visited.has(this)) return;
     visited.add(this);
@@ -269,6 +299,8 @@ export class ItemObject extends ElementObject {
    * Temporarily move the DOM element of an item to the root container during dragging,
    * so it can be positioned absolutely within the root container without affecting the
    * layout of its original container.
+   *
+   * @returns Nothing.
    */
   #hoistElementToRoot() {
     if (this.#rootContainer) {
@@ -284,8 +316,9 @@ export class ItemObject extends ElementObject {
 
   /**
    * Move the DOM element of an item back to its original container.
-   * @param container
-   * @returns
+   *
+   * @param container Container that should receive the dragged element.
+   * @returns Nothing.
    */
   #lowerElementToContainer(container: ItemContainer) {
     const element = this.element;
@@ -297,11 +330,12 @@ export class ItemObject extends ElementObject {
 
   /**
    * Move an item to a different container and index, updating the DOM and internal state accordingly.
-   * @param container
-   * @param item
-   * @param index
+   *
+   * @param container Destination container.
+   * @param item Item to move.
+   * @param index Destination index in the destination container.
    * @param updateDom Whether to update the DOM structure. This should be false if the DOM is already in the correct structure (e.g. during drag), to avoid unnecessary DOM operations.
-   * @returns
+   * @returns Nothing.
    */
   moveItemToContainer(
     container: ItemContainer,
@@ -354,6 +388,11 @@ export class ItemObject extends ElementObject {
    * Insert an item at a specific index in the item list and DOM.
    * If the index is past the end, the item is appended.
    * Note that this assumes the #itemOrderedList is already in the correct order.
+   *
+   * @param container Container that receives the item.
+   * @param item Item to insert.
+   * @param index Index where the item should be inserted.
+   * @returns Nothing.
    */
   insertItemAt(container: ItemContainer, item: ItemObject, index: number) {
     console.debug(
@@ -387,8 +426,11 @@ export class ItemObject extends ElementObject {
 
   /**
    * Remove an item from the item list and DOM.
+   *
+   * @param container Container that currently owns the item.
    * @param item The item to remove.
    * @param deleteElement Whether to delete the DOM element of the item.
+   * @returns Nothing.
    */
   removeItemFrom(
     container: ItemContainer,
@@ -413,6 +455,17 @@ export class ItemObject extends ElementObject {
     }
   }
 
+  /**
+   * Translate a frozen snapshot insertion index into the current live list.
+   *
+   * The live list may contain a ghost and no longer contain the dragged item,
+   * so this maps through the snapshot item that should appear after the target.
+   *
+   * @param container Container whose index is being translated.
+   * @param snapshotIndex Candidate index from the frozen snapshot list.
+   * @param draggedItem Item currently being dragged and omitted from live flow.
+   * @returns Equivalent insertion index in the live item list.
+   */
   #liveIndexFromSnapshotIndex(
     container: ItemObject,
     snapshotIndex: number,
@@ -436,6 +489,12 @@ export class ItemObject extends ElementObject {
     return liveIndex === -1 ? liveItems.length : liveIndex;
   }
 
+  /**
+   * Read the ghost's current live container and index.
+   *
+   * @param ghostItem Current ghost item, or null if no ghost exists.
+   * @returns Current ghost position, or null when the ghost is detached.
+   */
   #ghostInsertionPosition(
     ghostItem: ItemObject | null,
   ): { index: number; container: ItemObject | null } | null {
@@ -451,9 +510,11 @@ export class ItemObject extends ElementObject {
   /**
    * Create or remove a ghost element at the specified container and index.
    * A null container means the ghost element should be removed.
+   *
    * @param original The original item being dragged.
    * @param container The container to place the ghost element in, or null to remove it.
    * @param index The index at which to place the ghost element.
+   * @returns Nothing.
    */
   #updateGhostElement(
     original: ItemObject,
@@ -535,6 +596,12 @@ export class ItemObject extends ElementObject {
     // this.reorderItemList();
   }
 
+  /**
+   * Compute the current drop target and move the ghost when the target changes.
+   *
+   * @param item Item currently being dragged.
+   * @returns Nothing.
+   */
   updateDropTarget(item: ItemObject) {
     const root = (this.#rootContainer as unknown as ItemObject) ?? this;
     const target = determineDropTarget(item, root);

--- a/assets/snapsort/core/src/item.ts
+++ b/assets/snapsort/core/src/item.ts
@@ -1,5 +1,5 @@
 import { BaseObject, ElementObject, cloneDomProperty } from "@snap-engine/core";
-import type { ItemContainer } from "./container";
+import type { AnimationConfig, ItemContainer } from "./container";
 import { RectCollider, PointCollider } from "@snap-engine/core/collision";
 import type {
   dragStartProp,
@@ -8,12 +8,20 @@ import type {
   DomProperty,
 } from "@snap-engine/core";
 import { determineDropTarget, resetDropSnapshotDebugDump } from "./drop_target";
+import { AnimationObject } from "@snap-engine/core/animation";
 
 /**
  * How much to enlarge an item's hitbox while it is being dragged. The hitbox
  * grows around the item's center, so a factor of 1 leaves it unchanged.
  */
 const DRAG_HITBOX_SCALE = 4;
+const MIN_FLIP_DISTANCE = 0.5;
+
+interface FlipSnapshot {
+  item: ItemObject;
+  first: DOMRect | null;
+  last: DOMRect | null;
+}
 
 export class ItemObject extends ElementObject {
   // Container element is the parent element
@@ -317,6 +325,199 @@ export class ItemObject extends ElementObject {
   }
 
   /**
+   * Read the configured reorder animation for a container.
+   *
+   * @param container Container whose animation configuration should be used.
+   * @returns Reorder animation config, or null when reorder animation is disabled.
+   */
+  #reorderAnimationConfig(
+    container: ItemContainer | null,
+  ): AnimationConfig | null {
+    if (!container) return null;
+    const config = container.configuration;
+    if (config.animation === null) return null;
+    return config.animation?.reorder ?? null;
+  }
+
+  /**
+   * Collect all currently visible SnapSort items in this subtree.
+   *
+   * @param node Root of the subtree to collect.
+   * @param exclude Item that should not be animated, usually the actively dragged item.
+   * @param items Accumulator for collected items.
+   * @returns Items that can participate in FLIP animation.
+   */
+  #collectFlipItems(
+    node: ItemObject,
+    exclude: ItemObject,
+    items: ItemObject[] = [],
+  ): ItemObject[] {
+    for (const child of node.#itemOrderedList) {
+      if (child !== exclude && !child.isGhost && child.element) {
+        items.push(child);
+      }
+      this.#collectFlipItems(child, exclude, items);
+    }
+    return items;
+  }
+
+  /**
+   * Capture the current visual position for all FLIP animation candidates.
+   *
+   * `getBoundingClientRect()` intentionally includes active transform
+   * animations, so interrupted reorder animations restart from the element's
+   * actual on-screen position instead of its previous layout destination.
+   *
+   * @param root Root of the SnapSort tree being mutated.
+   * @param exclude Item that should not be animated.
+   * @returns Items with current visual rectangles captured as first positions.
+   */
+  #captureFlipSnapshot(root: ItemObject, exclude: ItemObject): FlipSnapshot[] {
+    return root.#collectFlipItems(root, exclude).map((item) => ({
+      item,
+      first: item.element!.getBoundingClientRect(),
+      last: null,
+    }));
+  }
+
+  /**
+   * Capture the final visual positions after the DOM mutation.
+   *
+   * @param snapshot Items whose final positions should be measured.
+   * @returns Nothing.
+   */
+  #captureFlipLast(snapshot: FlipSnapshot[]) {
+    for (const entry of snapshot) {
+      entry.last = entry.item.element?.getBoundingClientRect() ?? null;
+    }
+  }
+
+  /**
+   * Start FLIP animations from captured visual snapshots to the current layout.
+   *
+   * This method only writes transforms and starts SnapEngine animations. All
+   * layout reads must have happened in earlier READ stages.
+   *
+   * @param snapshot Visual rectangles captured before and after the DOM mutation.
+   * @param animationConfig Reorder animation configuration.
+   * @returns Nothing.
+   */
+  #playFlipAnimations(
+    snapshot: FlipSnapshot[],
+    animationConfig: AnimationConfig,
+  ) {
+    const movingAncestors = new Set<ItemObject>();
+    const duration = animationConfig.duration ?? 160;
+    const easing = animationConfig.timing_function ?? "ease-out";
+
+    for (const { item, first, last } of snapshot) {
+      const hasMovingAncestor =
+        movingAncestors.size > 0 &&
+        (() => {
+          let parent = item.parent;
+          while (parent) {
+            if (parent instanceof ItemObject && movingAncestors.has(parent)) {
+              return true;
+            }
+            parent = parent.parent;
+          }
+          return false;
+        })();
+      if (hasMovingAncestor || !item.element || !first || !last) continue;
+
+      const dx = first.x - last.x;
+      const dy = first.y - last.y;
+      if (Math.abs(dx) < MIN_FLIP_DISTANCE && Math.abs(dy) < MIN_FLIP_DISTANCE) {
+        continue;
+      }
+
+      movingAncestors.add(item);
+      const transformAt = (t: number) =>
+        `translate3d(${dx * (1 - t)}px, ${dy * (1 - t)}px, 0px)`;
+      const animation = new AnimationObject(
+        null,
+        {
+          $t: [0, 1],
+        },
+        {
+          duration,
+          easing,
+          tick: (vars) => {
+            item.element!.style.transform = transformAt(vars.$t);
+          },
+          finish: () => {
+            item.element!.style.transform = "";
+          },
+        },
+      );
+      item.element.style.transform = transformAt(0);
+      item.addAnimation(animation);
+      animation.play();
+    }
+  }
+
+  /**
+   * Run a DOM mutation with optional FLIP animation for affected items.
+   *
+   * @param container Container whose reorder animation config controls the mutation.
+   * @param original Actively dragged item, excluded from reorder animation.
+   * @param mutate DOM mutation to perform between first and last measurements.
+   * @returns Nothing.
+   */
+  #withReorderAnimation(
+    container: ItemContainer | null,
+    original: ItemObject,
+    mutate: () => void,
+  ) {
+    const animationConfig = this.#reorderAnimationConfig(container);
+    const root = (this.#rootContainer as unknown as ItemObject) ?? this;
+
+    if (!animationConfig) {
+      mutate();
+      return;
+    }
+
+    let snapshot: FlipSnapshot[] = [];
+    const queuePrefix = `snapsort-flip-${root.gid}`;
+
+    root.queueUpdate(
+      "READ_2",
+      () => {
+        snapshot = this.#captureFlipSnapshot(root, original);
+      },
+      `${queuePrefix}-read-first`,
+    );
+
+    root.queueUpdate(
+      "WRITE_2",
+      () => {
+        for (const { item } of snapshot) {
+          item.cancelAnimations();
+          item.element!.style.transform = "";
+        }
+        mutate();
+      },
+      `${queuePrefix}-mutate`,
+    );
+
+    root.queueUpdate(
+      "READ_3",
+      () => {
+        this.#captureFlipLast(snapshot);
+      },
+      `${queuePrefix}-read-last`,
+    );
+
+    root.queueUpdate(
+      "WRITE_3",
+      () => {
+        this.#playFlipAnimations(snapshot, animationConfig);
+      },
+      `${queuePrefix}-play`,
+    );
+  }
+
+  /**
    * Temporarily move the DOM element of an item to the root container during dragging,
    * so it can be positioned absolutely within the root container without affecting the
    * layout of its original container.
@@ -585,23 +786,32 @@ export class ItemObject extends ElementObject {
       ghostItem.centerPoint.local.y = origProp.height / 2;
     }
 
-    // Remove ghost from its current container before re-inserting at the new position
+    const moveGhost = () => {
+      // Remove ghost from its current container before re-inserting at the new position
+      if (ghostItem.parent) {
+        console.debug(
+          `[updateGhostElement] removing ghost from current container=${(ghostItem.container as unknown as ItemObject)?.gid}`,
+        );
+        this.removeItemFrom(ghostItem.container, ghostItem, false);
+      } else {
+        console.debug(
+          `[updateGhostElement] ghost has no parent, skipping remove`,
+        );
+      }
+      // Insert the ghost item at the new position in the DOM and item list.
+      // This also sets the ghost item's container to the new container.
+      console.debug(
+        `[updateGhostElement] inserting ghost at container=${(container as unknown as ItemObject).gid} index=${index}`,
+      );
+      this.insertItemAt(container, ghostItem, index);
+    };
+
     if (ghostItem.parent) {
-      console.debug(
-        `[updateGhostElement] removing ghost from current container=${(ghostItem.container as unknown as ItemObject)?.gid}`,
-      );
-      this.removeItemFrom(ghostItem.container, ghostItem, false);
+      this.#withReorderAnimation(container, original, moveGhost);
     } else {
-      console.debug(
-        `[updateGhostElement] ghost has no parent, skipping remove`,
-      );
+      moveGhost();
     }
-    // Insert the ghost item at the new position in the DOM and item list.
-    // This also sets the ghost item's container to the new container.
-    console.debug(
-      `[updateGhostElement] inserting ghost at container=${(container as unknown as ItemObject).gid} index=${index}`,
-    );
-    this.insertItemAt(container, ghostItem, index);
+
     // Root is responsible for maintaining the ghost element and removing it when necessary
     this.#rootContainer!.ghostItem = ghostItem;
 

--- a/assets/snapsort/core/src/layout_engine.ts
+++ b/assets/snapsort/core/src/layout_engine.ts
@@ -1,0 +1,355 @@
+import type { DomProperty } from "@snap-engine/core";
+
+export type LayoutDirection = "column" | "row";
+type AxisName = "x" | "y";
+type SizeName = "width" | "height";
+
+export interface FlowAxes {
+  direction: LayoutDirection;
+  main: AxisName;
+  cross: AxisName;
+  mainSize: SizeName;
+  crossSize: SizeName;
+}
+
+interface FlowMetrics {
+  mainStart: number;
+  crossStart: number;
+  mainGap: number;
+  crossGap: number;
+  lineCount: number;
+}
+
+export interface LayoutNode<T> {
+  value: T;
+  direction: LayoutDirection;
+  locked: boolean;
+  isGhost: boolean;
+  box: DomProperty;
+  children: LayoutNode<T>[];
+}
+
+export interface VirtualGhost<T> {
+  container: LayoutNode<T>;
+  index: number;
+  width: number;
+  height: number;
+}
+
+export interface VirtualDimensions {
+  width: number;
+  height: number;
+}
+
+export interface FlowPositionResult<T> {
+  itemPositions: Map<LayoutNode<T>, { x: number; y: number }>;
+  ghostPosition: { x: number; y: number } | null;
+}
+
+type FlowEntry<T> =
+  | { kind: "item"; item: LayoutNode<T>; width: number; height: number }
+  | { kind: "ghost"; width: number; height: number };
+
+export function flowAxesForDirection(direction: LayoutDirection): FlowAxes {
+  if (direction === "row") {
+    return {
+      direction,
+      main: "x",
+      cross: "y",
+      mainSize: "width",
+      crossSize: "height",
+    };
+  }
+
+  return {
+    direction,
+    main: "y",
+    cross: "x",
+    mainSize: "height",
+    crossSize: "width",
+  };
+}
+
+export function pointFromAxes(
+  axes: FlowAxes,
+  main: number,
+  cross: number,
+): { x: number; y: number } {
+  return axes.main === "x" ? { x: main, y: cross } : { x: cross, y: main };
+}
+
+export function contentBoxOrigin(prop: DomProperty): { x: number; y: number } {
+  return {
+    x: prop.x + prop.border.left + prop.padding.left,
+    y: prop.y + prop.border.top + prop.padding.top,
+  };
+}
+
+export function contentBoxSize(prop: DomProperty): {
+  width: number;
+  height: number;
+} {
+  return {
+    width: Math.max(
+      0,
+      prop.width -
+        prop.border.left -
+        prop.border.right -
+        prop.padding.left -
+        prop.padding.right,
+    ),
+    height: Math.max(
+      0,
+      prop.height -
+        prop.border.top -
+        prop.border.bottom -
+        prop.padding.top -
+        prop.padding.bottom,
+    ),
+  };
+}
+
+export function childRelativeOffset(
+  containerProp: DomProperty,
+  childProp: DomProperty,
+): { x: number; y: number } {
+  const origin = contentBoxOrigin(containerProp);
+  return {
+    x: childProp.x - origin.x,
+    y: childProp.y - origin.y,
+  };
+}
+
+export function layoutItems<T>(
+  container: LayoutNode<T>,
+  draggedItem: LayoutNode<T>,
+): LayoutNode<T>[] {
+  return container.children.filter(
+    (item) =>
+      item !== draggedItem && item.value !== draggedItem.value && !item.isGhost,
+  );
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+export function inferFlowLayoutMetrics<T>(
+  container: LayoutNode<T>,
+  axes: FlowAxes,
+): FlowMetrics {
+  const ordered = container.children.filter((item) => !item.isGhost);
+  if (ordered.length === 0) {
+    return {
+      mainStart: 0,
+      crossStart: 0,
+      mainGap: 0,
+      crossGap: 0,
+      lineCount: 0,
+    };
+  }
+
+  const firstOffset = childRelativeOffset(container.box, ordered[0].box);
+  const mainGaps: number[] = [];
+  const lines: Array<{ cross: number; crossSize: number }> = [];
+  let currentLine: { cross: number; crossSize: number } | null = null;
+  let previousOffset: { x: number; y: number } | null = null;
+
+  for (let i = 0; i < ordered.length; i++) {
+    const item = ordered[i];
+    const offset = childRelativeOffset(container.box, item.box);
+    const startsNewLine =
+      previousOffset != null &&
+      offset[axes.main] < previousOffset[axes.main] - 1;
+    if (!currentLine || startsNewLine) {
+      currentLine = {
+        cross: offset[axes.cross],
+        crossSize: item.box[axes.crossSize],
+      };
+      lines.push(currentLine);
+    } else {
+      currentLine.crossSize = Math.max(
+        currentLine.crossSize,
+        item.box[axes.crossSize],
+      );
+    }
+
+    const next = ordered[i + 1];
+    if (next) {
+      const nextOffset = childRelativeOffset(container.box, next.box);
+      const nextStartsNewLine = nextOffset[axes.main] < offset[axes.main] - 1;
+      if (!nextStartsNewLine) {
+        const gap =
+          nextOffset[axes.main] - (offset[axes.main] + item.box[axes.mainSize]);
+        if (gap >= 0) mainGaps.push(gap);
+      }
+    }
+    previousOffset = offset;
+  }
+
+  const crossGaps: number[] = [];
+  for (let i = 0; i < lines.length - 1; i++) {
+    const gap = lines[i + 1].cross - (lines[i].cross + lines[i].crossSize);
+    if (gap >= 0) crossGaps.push(gap);
+  }
+
+  return {
+    mainStart: firstOffset[axes.main],
+    crossStart: firstOffset[axes.cross],
+    mainGap: median(mainGaps),
+    crossGap: median(crossGaps),
+    lineCount: lines.length,
+  };
+}
+
+export function flowLayoutPositions<T>(
+  container: LayoutNode<T>,
+  draggedItem: LayoutNode<T>,
+  startX: number,
+  startY: number,
+  ghost?: VirtualGhost<T>,
+): FlowPositionResult<T> {
+  const axes = flowAxesForDirection(container.direction);
+  const contentSize = contentBoxSize(container.box);
+  const items = layoutItems(container, draggedItem);
+  const metrics = inferFlowLayoutMetrics(container, axes);
+  const entries: FlowEntry<T>[] = items.map((item) => {
+    const dimensions =
+      item.children.length > 0
+        ? virtualDimensions(item, draggedItem, ghost)
+        : item.box;
+    return {
+      kind: "item",
+      item,
+      width: dimensions.width,
+      height: dimensions.height,
+    };
+  });
+
+  if (ghost?.container === container) {
+    entries.splice(Math.max(0, Math.min(ghost.index, entries.length)), 0, {
+      kind: "ghost",
+      width: ghost.width,
+      height: ghost.height,
+    });
+  }
+
+  const itemPositions = new Map<LayoutNode<T>, { x: number; y: number }>();
+  let ghostPosition: { x: number; y: number } | null = null;
+  const origin = { x: startX, y: startY };
+  const lineMainStart = origin[axes.main] + metrics.mainStart;
+  const lineCrossStart = origin[axes.cross] + metrics.crossStart;
+  const maxMain = origin[axes.main] + contentSize[axes.mainSize];
+  const canWrap = axes.direction === "row" || metrics.lineCount > 1;
+  let cursorMain = lineMainStart;
+  let cursorCross = lineCrossStart;
+  let lineCrossSize = 0;
+
+  for (const entry of entries) {
+    const entryMainSize = entry[axes.mainSize];
+    const entryCrossSize = entry[axes.crossSize];
+    if (
+      canWrap &&
+      cursorMain > lineMainStart + 0.5 &&
+      cursorMain + entryMainSize > maxMain + 0.5
+    ) {
+      cursorMain = lineMainStart;
+      cursorCross += lineCrossSize + metrics.crossGap;
+      lineCrossSize = 0;
+    }
+
+    let position = pointFromAxes(axes, cursorMain, cursorCross);
+    if (entry.kind === "item" && entry.item.locked) {
+      const rel = childRelativeOffset(container.box, entry.item.box);
+      position = { x: startX + rel.x, y: startY + rel.y };
+      cursorMain = position[axes.main];
+      cursorCross = position[axes.cross];
+    }
+
+    if (entry.kind === "ghost") {
+      ghostPosition = position;
+    } else {
+      itemPositions.set(entry.item, position);
+    }
+
+    cursorMain += entryMainSize + metrics.mainGap;
+    lineCrossSize = Math.max(lineCrossSize, entryCrossSize);
+  }
+
+  return { itemPositions, ghostPosition };
+}
+
+export function virtualDimensions<T>(
+  container: LayoutNode<T>,
+  draggedItem: LayoutNode<T>,
+  ghost?: VirtualGhost<T>,
+): VirtualDimensions {
+  const axes = flowAxesForDirection(container.direction);
+  const items = layoutItems(container, draggedItem);
+  const flowPositions = flowLayoutPositions(
+    container,
+    draggedItem,
+    0,
+    0,
+    ghost,
+  );
+  let maxX = 0;
+  let maxY = 0;
+
+  for (const child of items) {
+    const dimensions =
+      child.children.length > 0
+        ? virtualDimensions(child, draggedItem, ghost)
+        : child.box;
+    const rel = childRelativeOffset(container.box, child.box);
+    const measured = { x: rel.x, y: rel.y };
+    const simulated = flowPositions.itemPositions.get(child) ?? measured;
+    maxX = Math.max(maxX, simulated.x + dimensions.width);
+    maxY = Math.max(maxY, simulated.y + dimensions.height);
+  }
+
+  if (ghost?.container === container && flowPositions.ghostPosition) {
+    maxX = Math.max(maxX, flowPositions.ghostPosition.x + ghost.width);
+    maxY = Math.max(maxY, flowPositions.ghostPosition.y + ghost.height);
+  }
+
+  const snapshotSize = {
+    width: container.box.width,
+    height: container.box.height,
+  };
+  const virtualSize = {
+    width:
+      container.box.border.left +
+      container.box.padding.left +
+      maxX +
+      container.box.padding.right +
+      container.box.border.right,
+    height:
+      container.box.border.top +
+      container.box.padding.top +
+      maxY +
+      container.box.padding.bottom +
+      container.box.border.bottom,
+  };
+
+  if (items.length === 0 && ghost?.container !== container) {
+    return snapshotSize;
+  }
+
+  if (axes.direction === "row") {
+    return {
+      width: snapshotSize.width,
+      height: Math.max(snapshotSize.height, virtualSize.height),
+    };
+  }
+
+  return {
+    width: snapshotSize.width,
+    height: virtualSize.height,
+  };
+}

--- a/assets/snapsort/svelte/src/Item.svelte
+++ b/assets/snapsort/svelte/src/Item.svelte
@@ -26,14 +26,12 @@
   });
 </script>
 
-<div class="snapsort-item-wrapper {className}" bind:this={itemObject.element} {style}>
-  <div class="snapsort-item">
-    {@render children()}
-  </div>
+<div class="snapsort-item {className}" bind:this={itemObject.element} {style}>
+  {@render children()}
 </div>
 
 <style>
-  .snapsort-item-wrapper {
+  .snapsort-item {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/demo/app.scss
+++ b/demo/app.scss
@@ -17,19 +17,12 @@ body {
 
 :root {
   --color-primary: #ff753a;
-  --color-secondary: #323233;
   --color-secondary-1: #f34336;
-  --color-secondary-2: #e8b72f;
-  --color-secondary-3: #84c122;
-  --color-secondary-4: #1982c4;
-  --color-secondary-5: #6a4c93;
-  --color-secondary-6: #f15bb5;
-  --color-secondary-7: #00bbf9;
   --color-accent: #ff0e56;
   --color-background: #ffffff;
   --color-background-tint: #f6f7f7;
   --color-background-dark: #7f8286;
-  --color-text: #555657;
+  --color-text: #333637;
 
   --size-256: 256px;
   --size-128: 128px;
@@ -49,7 +42,7 @@ body {
 }
 
 ::selection {
-  background: var(--color-secondary);
+  background: var(--color-primary);
   color: #fff;
 }
 
@@ -72,7 +65,6 @@ h6 {
 h1 {
   font-family: 'Geist Pixel Circle', sans-serif;
   font-size: 72px;
-  padding-bottom: var(--size-16);
 }
 
 h2,
@@ -110,11 +102,12 @@ h6 {
 
 p,
 a,
+blockquote,
 span,
 label,
 ul,
-li {
-  font-family: "Lato", sans-serif;
+ol {
+  font-family: "Geist", sans-serif;
   font-size: 1rem;
   color: var(--color-text);
   margin: 0;
@@ -128,10 +121,63 @@ li {
 
 pre, code {
   font-family: 'Geist Mono', monospace;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   > span, > span > span {
     font-family: 'Geist Mono', monospace;
-    font-size: 0.9rem;
+    font-size: 0.8rem;
+  }
+}
+
+article {
+  p, ul, ol {
+    margin-bottom: var(--size-32);
+  }
+
+  > p:has(+ ul),
+  > p:has(+ ol) {
+    margin-bottom: 0;
+  }
+
+  a {
+    color: var(--color-primary);
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+    text-decoration-thickness: 1px;
+  }
+
+  p code,
+  li code {
+    padding: 0 var(--size-4);
+    background: var(--color-background);
+    border-radius: var(--size-4);
+  }
+
+  pre {
+    margin: var(--size-16) 0;
+    padding: var(--size-16);
+    overflow: auto;
+    background: var(--color-background);
+    border-radius: var(--ui-radius);
+  }
+
+  pre code {
+    padding: 0;
+    background: transparent;
+    border-radius: 0;
+  }
+
+  hr {
+    border: 0;
+    border-top: 1px solid var(--color-background-dark);
+    margin: var(--size-32) 0;
+    opacity: 0.35;
+  }
+
+  blockquote {
+    margin: var(--size-16) 0;
+    padding-left: var(--size-16);
+    border-left: 2px solid var(--color-background-dark);
+    color: var(--color-background-dark);
   }
 }
 
@@ -139,7 +185,7 @@ pre, code {
 }
 
 
-section {  
+section {
   width: clamp(100px, 90%, 1200px);
   margin: 0 auto;
   box-sizing: border-box;
@@ -164,7 +210,7 @@ section {
   }
 
   &.five-column {
-    display: grid;  
+    display: grid;
     grid-template-columns: repeat(5, 1fr);
   }
 
@@ -289,11 +335,11 @@ section {
 
   &.shallow {
     box-shadow:
-      -2px -2px 4px 0px rgba(255, 255, 255, 0.162) inset,
+      -4px -4px 4px 0px rgba(255, 255, 255, 0.162) inset,
       1px 1px 3px -1px rgba(14, 26, 40, 0.31) inset,
-      -0.5px -0.5px 0.5px 0px rgba(73, 40, 49, 0.25),
-      0.5px 0.5px 0.5px 0px rgba(255, 255, 255, 0.25),
-      4px 4px 10px -7px rgba(40, 49, 73, 0.25) inset;
+      -1px -1px 0.5px 0px rgba(73, 40, 49, 0.25),
+      1px 1px 0.5px 0px rgba(255, 255, 255, 0.25),
+      6px 6px 10px -7px rgba(40, 49, 73, 0.25) inset;
   }
 }
 
@@ -341,6 +387,7 @@ label {
     gap: var(--size-4);
 
     input+span {
+      --checkbox-size: var(--size-12);
       width: var(--size-12);
       height: var(--size-12);
       --toggle-square-size: calc(var(--size-12) - 4px);
@@ -354,17 +401,17 @@ label {
 
 label:has(input[type="checkbox"]) {
   input+span {
+    --checkbox-size: var(--size-16);
     --toggle-square-size: calc(var(--size-16) - 4px);
+    --checkbox-expand-scale: calc(var(--checkbox-size) / var(--toggle-square-size));
     display: inline-flex;
     align-items: center;
     justify-content: center;
     position: relative;
-    width: var(--size-16);
-    height: var(--size-16);
+    width: var(--checkbox-size);
+    height: var(--checkbox-size);
     border-radius: calc(var(--size-4) - 1px);
     overflow: hidden;
-    transform-style: preserve-3d;
-    perspective: 600px;
 
     &::before,
     &::after {
@@ -372,8 +419,13 @@ label:has(input[type="checkbox"]) {
       width: var(--toggle-square-size);
       height: var(--toggle-square-size);
       border-radius: calc(var(--size-4) - 2px);
-      backface-visibility: hidden;
-      transition: transform 0.15s ease;
+      top: calc((var(--checkbox-size) - var(--toggle-square-size)) / 2);
+      left: var(--checkbox-size);
+      transform: scale(0.9);
+      transform-origin: center;
+      transition:
+        left 65ms ease-in 35ms,
+        transform 35ms ease-out;
       box-sizing: border-box;
       box-shadow:
         inset 0.5px 0.5px 0.5px rgba(255, 255, 255, 0.45),
@@ -396,7 +448,6 @@ label:has(input[type="checkbox"]) {
     &::after {
       content: "\2713";
       background: var(--color-primary);
-      transform: rotate3d(-1, 1, 0, -180deg);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -418,12 +469,12 @@ label:has(input[type="checkbox"]) {
     }
   }
 
-  input:checked+span::before {
-    transform: rotateY(180deg);
-  }
-
   input:checked+span::after {
-    transform: rotateY(360deg);
+    left: calc((var(--checkbox-size) - var(--toggle-square-size)) / 2);
+    transform: scale(var(--checkbox-expand-scale));
+    transition:
+      left 65ms ease-in,
+      transform 35ms ease-out 65ms;
   }
 }
 
@@ -566,10 +617,11 @@ input[type="range"] {
   height: 6px;
   // background: radial-gradient(hsl(from var(--color-background) h calc(s + 5) calc(l + 5)) 0%,
   //     hsl(from var(--color-background) h calc(s + 10) l) 70%);
+  background-color: var(--color-background-tint);
   box-shadow:
     -0.8px -0.8px 0.8px 0.2px rgba(9, 22, 36, 0.348),
     0.8px 0.8px 0.4px 0px rgba(255, 255, 255, 0.162),
-    0px 0px 4px 4px rgba(21, 28, 42, 0.84) inset;
+    0px 0px 2px 1px rgba(127, 130, 134, 0.18) inset;
   // overflow: hidden;
 
   &::-webkit-slider-thumb {
@@ -611,7 +663,7 @@ input[type="range"].large {
 button,
 .button {
 
-  --button-color: #fff; 
+  --button-color: #fff;
   --button-highlight-color: hsl(from var(--button-color) calc(h + 10) s calc(l + 20));
   --button-shadow-color: hsl(from var(--button-color) calc(h - 10) s calc(l - 20));
   color: var(--color-text);
@@ -688,7 +740,7 @@ button,
     filter: blur(0.2px);
   }
 
-  &:hover:not(:disabled) {
+  &:hover:not(:disabled):not(.active) {
     box-shadow: 0px 0px 1px 0.5px rgba(1, 11, 38, 0.157) inset,
       1px 1px 1px 0.5px hsl(from var(--button-highlight-color) h s l / 0.7) inset,
       -0.5px -0.5px 0.5px 0.5px hsl(from var(--button-shadow-color) h s l / 0.5) inset,
@@ -947,81 +999,34 @@ table {
     background-color: var(--color-primary);
     color: #fff;
   }
-
-  &.secondary {
-    background-color: var(--color-secondary);
-    color: #fff;
-  }
 }
 
 /* Progress Bar Styles */
 progress {
   width: 100%;
-  // height: var(--size-8);
+  height: var(--size-8);
   border-radius: var(--ui-radius);
   overflow: hidden;
   appearance: none;
   border: none;
-
+  background: var(--color-background-tint);
   box-shadow:
-    -0.8px -0.8px 0.8px 0px rgba(73, 40, 49, 0.25),
-    0.8px 0.8px 0.8px 0px rgba(255, 255, 255, 0.25),
-    -3px -2px 4px 0px rgba(23, 21, 18, 0.02) inset,
-    2px 2px 6.1px -1px rgba(40, 23, 14, 0.31) inset,
-    8px 8px 28px -7px rgba(73, 40, 49, 0.25) inset;
-  padding: 2px;
+    -0.8px -0.8px 2px 0.2px rgba(9, 22, 36, 0.348),
+    0.8px 0.8px 0.4px 0px rgba(255, 255, 255, 0.2),
+    0px 0px 2px 1px rgba(127, 130, 134, 0.18) inset;
 
   &::-webkit-progress-bar {
-    background: color-mix(in srgb, var(--color-secondary-1) 18%, transparent);
-    border-radius: calc(var(--ui-radius) - 2px);
+    background: var(--color-background-tint);
+    border-radius: var(--ui-radius) 0 0 var(--ui-radius);
   }
 
   &::-webkit-progress-value {
     background-color: var(--color-primary);
-    border-radius: calc(var(--ui-radius) - 2px);
-    box-shadow:
-      inset 1px 1px 0.5px 0px rgba(255, 255, 255, 0.242),
-      inset -0.5px -0.5px 0.5px 0px rgba(196, 223, 255, 0.56),
-      0px 0px 2px 0px rgba(23, 38, 83, 0.256),
-      1.5px 1.5px 2px -2px rgba(11, 28, 79, 0.377),
-      3px 3px 6px -1px rgba(48, 41, 58, 0.31);
+    border-radius: var(--ui-radius) 0 0 var(--ui-radius);
   }
 
   &::-moz-progress-bar {
     background-color: var(--color-primary);
-    border-radius: calc(var(--ui-radius) - 2px);
-  }
-
-  // &::-moz-progress-bar {
-  //   background: linear-gradient(
-  //     to right,
-  //     hsl(from var(--color-primary) h calc(s - 5) calc(l + 5)) 0%,
-  //     hsl(from var(--color-primary) h s l) 50%,
-  //     hsl(from var(--color-primary) h calc(s + 5) calc(l - 5)) 100%
-  //   );
-  //   border-radius: var(--size-8);
-  // }
-
-  &:indeterminate {
-    animation: progress-indeterminate 1.5s infinite linear;
-    background: linear-gradient(90deg,
-        var(--color-secondary-1) 0%,
-        var(--color-primary) 50%,
-        var(--color-secondary-1) 100%);
-    background-size: 200% 100%;
-  }
-
-  &:indeterminate::-webkit-progress-bar {
-    background: transparent;
-  }
-}
-
-@keyframes progress-indeterminate {
-  0% {
-    background-position: 200% 0;
-  }
-
-  100% {
-    background-position: -200% 0;
+    border-radius: var(--ui-radius) 0 0 var(--ui-radius);
   }
 }

--- a/demo/app.scss
+++ b/demo/app.scss
@@ -1,5 +1,5 @@
 
-@import url('https://fonts.googleapis.com/css2?family=Doto:wght@100..900&family=Lato&family=Lekton:ital,wght@0,400;0,700;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Doto:wght@100..900&family=Geist+Mono:ital,wght@0,100..900;1,100..900&family=Geist:wght@100..900&family=Lato&family=Lekton:ital,wght@0,400;0,700;1,400&display=swap');
 
 @font-face {
   font-family: 'Geist Pixel Circle';
@@ -16,7 +16,7 @@ body {
 }
 
 :root {
-  --color-primary: #fe620d;
+  --color-primary: #ff753a;
   --color-secondary: #323233;
   --color-secondary-1: #f34336;
   --color-secondary-2: #e8b72f;
@@ -27,7 +27,7 @@ body {
   --color-secondary-7: #00bbf9;
   --color-accent: #ff0e56;
   --color-background: #ffffff;
-  --color-background-tint: #f5f7f7;
+  --color-background-tint: #f6f7f7;
   --color-background-dark: #7f8286;
   --color-text: #555657;
 
@@ -66,27 +66,45 @@ h5,
 h6 {
   margin: 0;
   font-weight: 500;
-  font-family: 'Geist Pixel Circle', sans-serif;
   color: #373738;
 }
 
 h1 {
-  font-size: 4rem;
+  font-family: 'Geist Pixel Circle', sans-serif;
+  font-size: 72px;
   padding-bottom: var(--size-16);
 }
 
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Geist', sans-serif;
+}
+
 h2 {
-  font-size: 3rem;
+  font-size: 36px;
   margin-bottom: var(--size-16);
 }
 
 h3 {
-  font-size: 1.5rem;
+  font-size: 24px;
   margin-bottom: var(--size-12);
 }
 
 h4 {
-  font-size: 1.5rem;
+  font-size: 20px;
+  margin-bottom: var(--size-8);
+}
+
+h5 {
+  font-size: 18px;
+  margin-bottom: var(--size-8);
+}
+
+h6 {
+  font-size: 16px;
   margin-bottom: var(--size-8);
 }
 
@@ -118,21 +136,6 @@ pre, code {
 }
 
 @media (max-width: 720px) {
-  h1 {
-    font-size: 3rem;
-  }
-
-  h2 {
-    font-size: 2.5rem;
-  }
-
-  h3 {
-    font-size: 1.5rem;
-  }
-  h4 {
-    font-size: 1.2rem;
-  }
-
 }
 
 
@@ -615,6 +618,7 @@ button,
 
   cursor: pointer;
   font-family: "Lato", sans-serif;
+  font-size: 1rem;
   position: relative;
 
   border-radius: var(--ui-radius);
@@ -684,7 +688,7 @@ button,
     filter: blur(0.2px);
   }
 
-  &:hover {
+  &:hover:not(:disabled) {
     box-shadow: 0px 0px 1px 0.5px rgba(1, 11, 38, 0.157) inset,
       1px 1px 1px 0.5px hsl(from var(--button-highlight-color) h s l / 0.7) inset,
       -0.5px -0.5px 0.5px 0.5px hsl(from var(--button-shadow-color) h s l / 0.5) inset,
@@ -749,7 +753,7 @@ button,
 
   &.small {
     padding: var(--size-2) var(--size-8);
-    font-size: 12px;
+    font-size: 1rem;
     line-height: 0.8;
   }
 }
@@ -757,6 +761,7 @@ button,
 input[type="number"],
 input[type="text"] {
   font-family: "IBM Plex Mono", monospace;
+  font-size: 1rem;
   user-select: none;
   border: none;
   border-radius: var(--ui-radius);
@@ -785,6 +790,7 @@ input[type="date"],
 input[type="datetime-local"],
 input[type="time"] {
   font-family: "IBM Plex Mono", monospace;
+  font-size: 1rem;
   user-select: none;
   border: none;
   border-radius: var(--ui-radius);
@@ -819,7 +825,7 @@ select,
 
 select {
   font-family: "IBM Plex Mono", monospace;
-  font-size: 14px;
+  font-size: 1rem;
   color: var(--color-text);
   user-select: none;
   cursor: pointer;
@@ -966,7 +972,7 @@ progress {
   padding: 2px;
 
   &::-webkit-progress-bar {
-    background: transparent;
+    background: color-mix(in srgb, var(--color-secondary-1) 18%, transparent);
     border-radius: calc(var(--ui-radius) - 2px);
   }
 
@@ -979,6 +985,11 @@ progress {
       0px 0px 2px 0px rgba(23, 38, 83, 0.256),
       1.5px 1.5px 2px -2px rgba(11, 28, 79, 0.377),
       3px 3px 6px -1px rgba(48, 41, 58, 0.31);
+  }
+
+  &::-moz-progress-bar {
+    background-color: var(--color-primary);
+    border-radius: calc(var(--ui-radius) - 2px);
   }
 
   // &::-moz-progress-bar {
@@ -994,9 +1005,9 @@ progress {
   &:indeterminate {
     animation: progress-indeterminate 1.5s infinite linear;
     background: linear-gradient(90deg,
-        var(--color-secondary) 0%,
+        var(--color-secondary-1) 0%,
         var(--color-primary) 50%,
-        var(--color-secondary) 100%);
+        var(--color-secondary-1) 100%);
     background-size: 200% 100%;
   }
 

--- a/demo/svelte/src/Landing.svelte
+++ b/demo/svelte/src/Landing.svelte
@@ -7,10 +7,9 @@
   
   // New demos
   import NodeUIDemo from "./demo/node_ui_demo/NodeUIDemo.svelte";
-  import DragDropDemo from "./demo/drag_drop/DragDropDemo.svelte";
+  import DropSnapNestedDemo from "./demo/drop_snap_nested/DropSnapNestedDemo.svelte";
   import CollisionDemo from "./demo/collision/CollisionDemo.svelte";
   import CSSShowcase from "./demo/css_showcase/CSSShowcase.svelte";
-  import NestedItemsDemo from "./demo/nested_items/NestedItemsDemo.svelte";
 
   type DemoOption = {
     label: string;
@@ -19,19 +18,21 @@
 
   const demoOptions: DemoOption[] = [
     { label: "Welcome Background", value: "welcome" },
-    { label: "CSS Showcase", value: "css_showcase" },
+    { label: "Style Guide", value: "css_showcase" },
     { label: "Animation", value: "gallery" },
     { label: "Input", value: "drag" },
     { label: "Snap Line", value: "node_ui" },
-    { label: "Drop & Snap", value: "drag_drop" },
+    { label: "SnapSort", value: "drop_snap_nested" },
     { label: "Collision", value: "collision" },
-    { label: "Nested Items", value: "nested_items" },
   ];
 
   function getDemoFromUrl() {
     if (typeof window === "undefined") return "welcome";
     const params = new URLSearchParams(window.location.search);
     const demo = params.get("demo");
+    if (demo === "drag_drop" || demo === "nested_items") {
+      return "drop_snap_nested";
+    }
     if (demo && demoOptions.some((o) => o.value === demo)) {
       return demo;
     }
@@ -41,10 +42,9 @@
   let selectedDemo = $state(getDemoFromUrl());
   let debugEnabled = $state(false);
   let dragDemoRef: DragDemo | null = $state(null);
-  let dragDropDemoRef: DragDropDemo | null = $state(null);
-  let nestedItemsDemoRef: NestedItemsDemo | null = $state(null);
+  let dropSnapNestedDemoRef: DropSnapNestedDemo | null = $state(null);
 
-  const debugSupportedDemos = ["drag", "drag_drop", "nested_items"];
+  const debugSupportedDemos = ["drag", "drop_snap_nested"];
 
   $effect(() => {
     if (typeof window !== "undefined") {
@@ -73,22 +73,20 @@
     const target = event.currentTarget as HTMLInputElement;
     debugEnabled = target.checked;
     dragDemoRef?.setDebug(debugEnabled);
-    dragDropDemoRef?.setDebug(debugEnabled);
-    nestedItemsDemoRef?.setDebug(debugEnabled);
+    dropSnapNestedDemoRef?.setDebug(debugEnabled);
   }
 
   $effect(() => {
     if (!debugSupportedDemos.includes(selectedDemo) && debugEnabled) {
       debugEnabled = false;
       dragDemoRef?.setDebug(false);
-      dragDropDemoRef?.setDebug(false);
-      nestedItemsDemoRef?.setDebug(false);
+      dropSnapNestedDemoRef?.setDebug(false);
     }
   });
 </script>
 
 <div class="landing-container">
-  <div class="demo-selector">
+  <div class="demo-selector" class:dev-navbar={selectedDemo === "drop_snap_nested"}>
     <label for="demo-select">Select Demo:</label>
     <select id="demo-select" bind:value={selectedDemo}>
       {#each demoOptions as option}
@@ -121,12 +119,10 @@
       <DragDemo bind:this={dragDemoRef} />
     {:else if selectedDemo === "node_ui"}
       <NodeUIDemo />
-    {:else if selectedDemo === "drag_drop"}
-      <DragDropDemo bind:this={dragDropDemoRef} />
+    {:else if selectedDemo === "drop_snap_nested"}
+      <DropSnapNestedDemo bind:this={dropSnapNestedDemoRef} />
     {:else if selectedDemo === "collision"}
       <CollisionDemo />
-    {:else if selectedDemo === "nested_items"}
-      <NestedItemsDemo bind:this={nestedItemsDemoRef} />
     {/if}
   </div>
 </div>
@@ -149,10 +145,9 @@
     gap: var(--size-12);
     z-index: 100;
     box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.05);
-    position: absolute;
     width: 100%;
     box-sizing: border-box;
-    top: 0;
+    margin-bottom: var(--size-32);
   }
 
   .demo-selector label {
@@ -204,5 +199,44 @@
 
   .debug-toggle.disabled {
     opacity: 0.4;
+  }
+
+  .demo-selector.dev-navbar {
+    background: #fff;
+    border-bottom: 2px solid #000;
+    box-shadow: none;
+    margin-bottom: 0;
+
+    label,
+    select {
+      font-family: "Geist", sans-serif;
+      color: #000;
+    }
+
+    select {
+      background: #fff;
+      border: 2px solid #000;
+      border-radius: 0;
+      box-shadow: none;
+      font-size: 1rem;
+    }
+
+    select:focus {
+      border-color: #000;
+      box-shadow: none;
+    }
+
+    :global(input[type="checkbox"] + span) {
+      background: #fff;
+      border: 2px solid #000;
+      border-radius: 0;
+      box-shadow: none;
+    }
+
+    :global(input[type="checkbox"] + span::before),
+    :global(input[type="checkbox"] + span::after) {
+      box-shadow: none;
+      border-radius: 0;
+    }
   }
 </style>

--- a/demo/svelte/src/demo/css_showcase/CSSShowcase.svelte
+++ b/demo/svelte/src/demo/css_showcase/CSSShowcase.svelte
@@ -49,19 +49,68 @@
     <!-- Typography Section -->
     <section class="showcase-section">
       <h2>Typography</h2>
-      <div>
-        <h1>Heading 1</h1>
-        <h2>Heading 2</h2>
-        <h3>Heading 3</h3>
-        <h4>Heading 4</h4>
-        <h5>Heading 5</h5>
-        <h6>Heading 6</h6>
+      <article class="type-article prose">
+        <h1>Inside Snap Engine</h1>
         <p>
-          This is a paragraph. 
+          Snap Engine is an interaction layer for building direct,
+          responsive web tools. It coordinates input, layout reads, DOM writes,
+          animation, collision, and debug overlays through a shared frame loop.
         </p>
-        <a href="#typography">This is a link element</a>
-        <p class="mono-sample">Geist Mono is the monospace font.</p>
-      </div>
+
+        <hr />
+
+        <h2>A Staged Frame Loop</h2>
+        <p>
+          Work is split into explicit read and write stages. Reads collect
+          geometry, writes update the DOM, and optional systems such as
+          animation and collision run in known places between them.
+        </p>
+        <ul>
+          <li>Input events collect user intent.</li>
+          <li>Read stages measure the current document.</li>
+          <li>Write stages apply DOM and transform updates.</li>
+        </ul>
+
+        <h3>Objects Own Their Behavior</h3>
+        <p>
+          Engine objects bind input handlers, transforms, DOM elements, and
+          debugging metadata in one place. That keeps interaction code local
+          without forcing each component to manually orchestrate a render loop.
+        </p>
+        <blockquote>
+          The most useful abstraction is the one that keeps a frame predictable.
+        </blockquote>
+
+        <pre class="slot shallow"><code>object.queueUpdate("READ_1", () => &#123;
+  object.readDom(true, "READ_1");
+&#125;);
+
+object.queueUpdate("WRITE_1", () => &#123;
+  object.writeTransform();
+&#125;);</code></pre>
+
+        <h4>Implementation Note</h4>
+        <p>
+          Inline code such as <code>queueUpdate()</code> should sit comfortably
+          inside body copy without changing the rhythm of the line. Related API
+          notes can point to <a href="#buttons">controls</a> or
+          <a href="#colors">color tokens</a> without feeling louder than the
+          surrounding text.
+        </p>
+        <ol>
+          <li>Capture the current state.</li>
+          <li>Apply the smallest possible mutation.</li>
+          <li>Animate from the old visual state into the new one.</li>
+        </ol>
+
+        <h5>Observation</h5>
+        <p class="mono-sample">
+          Geist Mono is reserved for code, labels, debug output, and compact
+          technical annotations.
+        </p>
+
+
+      </article>
     </section>
 
     <!-- Colors Section -->
@@ -101,7 +150,7 @@
       <div class="card-slot-grid">
         <div class="card ground">
           <h3>Card</h3>
-          <p>A ground card variant with subtle shadows to make it look as if 
+          <p>A ground card variant with subtle shadows to make it look as if
             it is a bump on the ground.
           </p>
         </div>
@@ -111,7 +160,7 @@
             <span>Inset container for drop zones and recessed UI areas</span>
           </div>
         </div>
-       
+
       </div>
     </section>
 
@@ -343,7 +392,7 @@
   .showcase-section {
     background: var(--color-background-tint);
     border-radius: 12px;
-    padding: var(--size-32);
+    padding: var(--size-48);
     margin-bottom: var(--size-48);
 
     > h2 {
@@ -356,8 +405,29 @@
     }
   }
 
-  .mono-sample {
-    font-family: "Geist Mono", monospace;
+  .type-article {
+    column-count: 2;
+    column-gap: var(--size-48);
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    pre {
+      break-inside: avoid;
+    }
+
+    h1 {
+      column-span: all;
+      margin-bottom: var(--size-24);
+    }
+  }
+
+  @media (max-width: 900px) {
+    .type-article {
+      column-count: 1;
+    }
   }
 
   .controls-stack {

--- a/demo/svelte/src/demo/css_showcase/CSSShowcase.svelte
+++ b/demo/svelte/src/demo/css_showcase/CSSShowcase.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  type ShowcaseStyle = "existing" | "dev";
+
   let checkboxChecked = $state(false);
   // let radioValue = $state("option1");
   let rangeValue = $state(50);
@@ -7,11 +9,41 @@
   let selectValue = $state("option1");
   let dateValue = $state("");
   let progressValue = $state(65);
+  let showcaseStyle = $state<ShowcaseStyle>("existing");
+  let toggleEnabled = $state(true);
+  let devStyleLoaded = false;
+
+  async function setShowcaseStyle(style: ShowcaseStyle) {
+    showcaseStyle = style;
+
+    if (style === "dev" && !devStyleLoaded) {
+      await import("./style.dev.scss");
+      devStyleLoaded = true;
+    }
+  }
 </script>
 
-
-    <section class="showcase-section">
-      <h1>CSS Showcase</h1>
+<div class="css-showcase" data-showcase-style={showcaseStyle}>
+    <section class="showcase-section showcase-header">
+      <div>
+        <h1 class="showcase-title">Style<br />Guide</h1>
+        <div class="style-selector" aria-label="Style">
+          <button
+            class:active={showcaseStyle === "existing"}
+            type="button"
+            onclick={() => setShowcaseStyle("existing")}
+          >
+            Default
+          </button>
+          <button
+            class:active={showcaseStyle === "dev"}
+            type="button"
+            onclick={() => setShowcaseStyle("dev")}
+          >
+            Dev
+          </button>
+        </div>
+      </div>
     </section>
 
     <!-- Typography Section -->
@@ -28,6 +60,7 @@
           This is a paragraph. 
         </p>
         <a href="#typography">This is a link element</a>
+        <p class="mono-sample">Geist Mono is the monospace font.</p>
       </div>
     </section>
 
@@ -35,55 +68,27 @@
     <section class="showcase-section">
       <h2>Color Palette</h2>
       <div class="color-grid">
-        <div class="color-swatch primary card ground">
+        <div class="color-swatch primary">
           <span class="light">Primary</span>
           <code>#ff753a</code>
         </div>
-        <div class="color-swatch secondary card">
-          <span class="light">Secondary</span>
-          <code>#1e2659</code>
-        </div>
-        <div class="color-swatch secondary-1 card">
+        <div class="color-swatch secondary-1">
           <span class="light">Secondary 1</span>
           <code>#f34336</code>
         </div>
-        <div class="color-swatch secondary-2 card">
-          <span class="light">Secondary 2</span>
-          <code>#e8b72f</code>
-        </div>
-        <div class="color-swatch secondary-3 card">
-          <span class="light">Secondary 3</span>
-          <code>#84c122</code>
-        </div>
-        <div class="color-swatch secondary-4 card">
-          <span class="light">Secondary 4</span>
-          <code>#1982c4</code>
-        </div>
-        <div class="color-swatch secondary-5 card">
-          <span class="light">Secondary 5</span>
-          <code>#6a4c93</code>
-        </div>
-        <div class="color-swatch secondary-6 card">
-          <span class="light">Secondary 6</span>
-          <code>#f15bb5</code>
-        </div>
-        <div class="color-swatch secondary-7 card">
-          <span class="light">Secondary 7</span>
-          <code>#00bbf9</code>
-        </div>
-        <div class="color-swatch accent card  ">
+        <div class="color-swatch accent">
           <span class="light">Accent</span>
           <code>#4b403a</code>
         </div>
-        <div class="color-swatch background card">
+        <div class="color-swatch background">
           <span>Background</span>
           <code>#f6f5f4</code>
         </div>
-        <div class="color-swatch background-tint card">
+        <div class="color-swatch background-tint">
           <span>Background Tint</span>
           <code>#e7e3e2</code>
         </div>
-        <div class="color-swatch text card">
+        <div class="color-swatch text">
           <span class="light">Text</span>
           <code>#453e3a</code>
         </div>
@@ -94,16 +99,8 @@
     <section class="showcase-section">
       <h2>Cards & Slots</h2>
       <div class="card-slot-grid">
-        <div class="card">
-          <h3>Default Card</h3>
-          <p>A standard card with subtle shadow and border effects.</p>
-        </div>
-        <div class="card float">
-          <h3>Float Card</h3>
-          <p>A floating card variant with enhanced shadow for elevation.</p>
-        </div>
-           <div class="card ground">
-          <h3>Ground Card</h3>
+        <div class="card ground">
+          <h3>Card</h3>
           <p>A ground card variant with subtle shadows to make it look as if 
             it is a bump on the ground.
           </p>
@@ -118,308 +115,201 @@
       </div>
     </section>
 
-    <!-- Buttons Section -->
+    <!-- Buttons & Form Elements Section -->
     <section class="showcase-section">
-      <h2>Buttons</h2>
-      <div class="">
-        <div class="button-row">
-          <button>Default Button</button>
-          <button class="primary">Primary Button</button>
-          <button class="small">Small Button</button>
-          <button class="active">Active State</button>
-          <button class="primary" disabled>Disabled</button>
-        </div>
-        <div class="button-row" style="margin-top: var(--size-16);">
-          <span class="button">Button Class on Span</span>
-          <a href="#buttons" class="button primary">Link as Button</a>
-        </div>
-      </div>
-    </section>
-
-    <!-- Form Elements Section -->
-    <section class="showcase-section three-column">
-      <h2 style="grid-column: span 3;">Form Elements</h2>
-      
-   
-       
-
-        <!-- Checkboxes -->
-        <div class="card">
-          <h3>Checkboxes</h3>
-          <div class="form-group">
-            <label class="checkbox-label">
-              <input type="checkbox" bind:checked={checkboxChecked} />
-              <span></span>
-              Unchecked by default
-            </label>
-          </div>
-          <div class="form-group">
-            <label class="checkbox-label">
-              <input type="checkbox" checked />
-              <span></span>
-              Checked by default
-            </label>
-          </div>
-          <div class="form-group">
-            <label class="checkbox-label">
-              <input type="checkbox" />
-              <span></span>
-              Another option
-            </label>
-          </div>
-        </div>
-
-        <!-- Radio Buttons -->
-        <div class="card">
-          <h3>Radio Buttons</h3>
-          <div class="form-group">
-            <label class="radio-label">
-              <input type="radio" name="demo-radio" value="option1"  />
-              <span></span>
-              Option One
-            </label>
-          </div>
-          <div class="form-group">
-            <label class="radio-label">
-              <input type="radio" name="demo-radio" value="option2" />
-              <span></span>
-              Option Two
-            </label>
-          </div>
-          <div class="form-group">
-            <label class="radio-label">
-              <input type="radio" name="demo-radio" value="option3"  />
-              <span></span>
-              Option Three
-            </label>
-          </div>
-        </div>
-
-        <!-- Range Sliders -->
-        <div class="card">
-          <h3>Range Sliders</h3>
-          <div class="form-group">
-            <label>Default Range</label>
-            <input type="range" min="0" max="100" bind:value={rangeValue} />
-            <span class="range-value">{rangeValue}</span>
-          </div>
-          <div class="form-group">
-            <label>Large Range</label>
-            <input type="range" class="large" min="0" max="100" value="75" />
-          </div>
-        </div>
-
-        <!-- Dropdowns/Selects -->
-        <div class="card">
-          <h3>Dropdowns</h3>
-          <div class="form-group">
-            <label for="select-default">Default Select</label>
-            <select id="select-default" bind:value={selectValue}>
-              <option value="option1">Option One</option>
-              <option value="option2">Option Two</option>
-              <option value="option3">Option Three</option>
-              <option value="option4">Option Four</option>
-            </select>
-          </div>
-          <div class="form-group">
-            <label for="select-grouped">Grouped Options</label>
-            <select id="select-grouped">
-              <optgroup label="Category A">
-                <option value="a1">Item A1</option>
-                <option value="a2">Item A2</option>
-              </optgroup>
-              <optgroup label="Category B">
-                <option value="b1">Item B1</option>
-                <option value="b2">Item B2</option>
-              </optgroup>
-            </select>
-          </div>
-          <div class="form-group">
-            <label for="select-disabled">Disabled Select</label>
-            <select id="select-disabled" disabled>
-              <option>Cannot change this</option>
-            </select>
-          </div>
-        </div>
-
-        <!-- Date Selectors -->
-        <div class="card">
-          <h3>Date Selectors</h3>
-          <div class="form-group">
-            <label for="date-input">Date Input</label>
-            <input type="date" id="date-input" bind:value={dateValue} />
-          </div>
-          <div class="form-group">
-            <label for="datetime-input">DateTime Input</label>
-            <input type="datetime-local" id="datetime-input" />
-          </div>
-          <div class="form-group">
-            <label for="time-input">Time Input</label>
-            <input type="time" id="time-input" />
-          </div>
-        </div>
-
-        <!-- Progress Bars -->
-        <div class="card">
-          <h3>Progress Bars</h3>
-          <div class="form-group">
-            <label>Default Progress ({progressValue}%)</label>
-            <progress value={progressValue} max="100"></progress>
-          </div>
-          <div class="form-group">
-            <label>Complete (100%)</label>
-            <progress value="100" max="100"></progress>
-          </div>
-          <div class="form-group">
-            <label>Indeterminate</label>
-            <progress></progress>
-          </div>
-          <div class="form-group">
-            <label>Adjust Progress</label>
-            <input type="range" min="0" max="100" bind:value={progressValue} />
-          </div>
-        </div>
-
-         <!-- Text Inputs -->
-        <div class="card">
-          <h3>Text Inputs</h3>
-          <div class="form-group">
-            <label for="text-input">Text Input</label>
-            <input type="text" id="text-input" bind:value={textValue} placeholder="Enter text..." />
-          </div>
-          <div class="form-group">
-            <label for="number-input">Number Input</label>
-            <input type="number" id="number-input" bind:value={numberValue} />
-          </div>
-          <div class="form-group">
-            <label for="disabled-input">Disabled Text Input</label>
-            <input type="text" id="disabled-input" value="Cannot edit this" disabled />
-          </div>
-          <div class="form-group">
-            <label for="disabled-number">Disabled Number Input</label>
-            <input type="number" id="disabled-number" value="100" disabled />
-          </div>
-        </div>
-
-    </section>
-
-    <!-- Tables Section -->
-    <section class="showcase-section">
-      <h2>Tables</h2>
-      <div class="card">
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Type</th>
-              <th>Status</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Component A</td>
-              <td>Primary</td>
-              <td><span class="badge success">Active</span></td>
-              <td>128</td>
-            </tr>
-            <tr>
-              <td>Component B</td>
-              <td>Secondary</td>
-              <td><span class="badge warning">Pending</span></td>
-              <td>64</td>
-            </tr>
-            <tr>
-              <td>Component C</td>
-              <td>Accent</td>
-              <td><span class="badge error">Inactive</span></td>
-              <td>256</td>
-            </tr>
-            <tr>
-              <td>Component D</td>
-              <td>Primary</td>
-              <td><span class="badge">Default</span></td>
-              <td>512</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      
-      <div class="card" style="margin-top: var(--size-24);">
-        <h3>Striped Table</h3>
-        <table class="striped">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Description</th>
-              <th>Created</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>001</td>
-              <td>First item in the list</td>
-              <td>2025-01-15</td>
-            </tr>
-            <tr>
-              <td>002</td>
-              <td>Second item in the list</td>
-              <td>2025-02-20</td>
-            </tr>
-            <tr>
-              <td>003</td>
-              <td>Third item in the list</td>
-              <td>2025-03-10</td>
-            </tr>
-            <tr>
-              <td>004</td>
-              <td>Fourth item in the list</td>
-              <td>2025-04-05</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </section>
-
-    <!-- Spacing Scale Section -->
-    <section class="showcase-section">
-      <h2>Spacing Scale</h2>
-      <div class="card">
-        <div class="spacing-demo">
-          {#each [2, 4, 8, 12, 16, 24, 32, 48, 64] as size}
-            <div class="spacing-item">
-              <div class="spacing-box" style="width: {size}px; height: {size}px;"></div>
-              <code>--size-{size}</code>
+      <h2>Buttons & Form Elements</h2>
+      <div class="controls-stack">
+        <div class="controls-top">
+          <div>
+            <h3>Buttons</h3>
+            <div class="button-row">
+              <button>Default Button</button>
+              <button class="primary">Primary Button</button>
+              <button class="small">Small Button</button>
+              <button class="active">Active State</button>
+              <button class="primary" disabled>Disabled</button>
             </div>
-          {/each}
+          </div>
+          <div>
+            <h3>Toggles</h3>
+            <div class="toggle-demo">
+              <div
+                class="mini-toggle-switch slot"
+                class:enabled={toggleEnabled}
+                onclick={() => (toggleEnabled = !toggleEnabled)}
+                role="switch"
+                aria-checked={toggleEnabled}
+                tabindex="0"
+                onkeydown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    toggleEnabled = !toggleEnabled;
+                  }
+                }}
+              >
+                <div class="mini-toggle-knob disk"></div>
+              </div>
+              <span>{toggleEnabled ? "On" : "Off"}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-grid">
+          <div class="form-control-group">
+            <h3>Checkboxes</h3>
+            <div class="form-group">
+              <label class="checkbox-label">
+                <input type="checkbox" bind:checked={checkboxChecked} />
+                <span></span>
+                Unchecked by default
+              </label>
+            </div>
+            <div class="form-group">
+              <label class="checkbox-label">
+                <input type="checkbox" checked />
+                <span></span>
+                Checked by default
+              </label>
+            </div>
+            <div class="form-group">
+              <label class="checkbox-label">
+                <input type="checkbox" />
+                <span></span>
+                Another option
+              </label>
+            </div>
+          </div>
+
+          <div class="form-control-group">
+            <h3>Radio Buttons</h3>
+            <div class="form-group">
+              <label class="radio-label">
+                <input type="radio" name="demo-radio" value="option1"  />
+                <span></span>
+                Option One
+              </label>
+            </div>
+            <div class="form-group">
+              <label class="radio-label">
+                <input type="radio" name="demo-radio" value="option2" />
+                <span></span>
+                Option Two
+              </label>
+            </div>
+            <div class="form-group">
+              <label class="radio-label">
+                <input type="radio" name="demo-radio" value="option3"  />
+                <span></span>
+                Option Three
+              </label>
+            </div>
+          </div>
+
+          <div class="form-control-group">
+            <h3>Range Sliders</h3>
+            <div class="form-group">
+              <label>Default Range</label>
+              <input type="range" min="0" max="100" bind:value={rangeValue} />
+              <span class="range-value">{rangeValue}</span>
+            </div>
+            <div class="form-group">
+              <label>Large Range</label>
+              <input type="range" class="large" min="0" max="100" value="75" />
+            </div>
+          </div>
+
+          <div class="form-control-group">
+            <h3>Dropdowns</h3>
+            <div class="form-group">
+              <label for="select-default">Default Select</label>
+              <select id="select-default" bind:value={selectValue}>
+                <option value="option1">Option One</option>
+                <option value="option2">Option Two</option>
+                <option value="option3">Option Three</option>
+                <option value="option4">Option Four</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="select-grouped">Grouped Options</label>
+              <select id="select-grouped">
+                <optgroup label="Category A">
+                  <option value="a1">Item A1</option>
+                  <option value="a2">Item A2</option>
+                </optgroup>
+                <optgroup label="Category B">
+                  <option value="b1">Item B1</option>
+                  <option value="b2">Item B2</option>
+                </optgroup>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="select-disabled">Disabled Select</label>
+              <select id="select-disabled" disabled>
+                <option>Cannot change this</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-control-group">
+            <h3>Date Selectors</h3>
+            <div class="form-group">
+              <label for="date-input">Date Input</label>
+              <input type="date" id="date-input" bind:value={dateValue} />
+            </div>
+            <div class="form-group">
+              <label for="datetime-input">DateTime Input</label>
+              <input type="datetime-local" id="datetime-input" />
+            </div>
+            <div class="form-group">
+              <label for="time-input">Time Input</label>
+              <input type="time" id="time-input" />
+            </div>
+          </div>
+
+          <div class="form-control-group">
+            <h3>Progress Bars</h3>
+            <div class="form-group">
+              <label>Default Progress ({progressValue}%)</label>
+              <progress value={progressValue} max="100"></progress>
+            </div>
+            <div class="form-group">
+              <label>Complete (100%)</label>
+              <progress value="100" max="100"></progress>
+            </div>
+            <div class="form-group">
+              <label>Indeterminate</label>
+              <progress></progress>
+            </div>
+            <div class="form-group">
+              <label>Adjust Progress</label>
+              <input type="range" min="0" max="100" bind:value={progressValue} />
+            </div>
+          </div>
+
+          <div class="form-control-group">
+            <h3>Text Inputs</h3>
+            <div class="form-group">
+              <label for="text-input">Text Input</label>
+              <input type="text" id="text-input" bind:value={textValue} placeholder="Enter text..." />
+            </div>
+            <div class="form-group">
+              <label for="number-input">Number Input</label>
+              <input type="number" id="number-input" bind:value={numberValue} />
+            </div>
+            <div class="form-group">
+              <label for="disabled-input">Disabled Text Input</label>
+              <input type="text" id="disabled-input" value="Cannot edit this" disabled />
+            </div>
+            <div class="form-group">
+              <label for="disabled-number">Disabled Number Input</label>
+              <input type="number" id="disabled-number" value="100" disabled />
+            </div>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- CSS Variables Reference -->
-    <section class="showcase-section">
-      <h2>CSS Variables Reference</h2>
-      <div class="card">
-        <h3>Colors</h3>
-        <code class="code-block">
---color-primary: #ff753a;
---color-secondary: #1e2659;
---color-accent: #4b403a;
---color-background: #f6f5f4;
---color-background-tint: #e7e3e2;
---color-background-dark: #8b817d;
---color-text: #453e3a;
-        </code>
-        
-        <h3 style="margin-top: var(--size-16);">Sizing</h3>
-        <code class="code-block">
---size-256, --size-128, --size-96, --size-80
---size-64, --size-48, --size-32, --size-24
---size-16, --size-12, --size-8, --size-4, --size-2
---ui-radius: var(--size-8);
-        </code>
-      </div>
-    </section>
+</div>
 
 
 <style lang="scss">
@@ -427,37 +317,71 @@
     width: 100%;
     height: 100%;
     position: relative;
+    background: #fff;
   }
 
- 
+  .showcase-header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    text-align: left;
+    height: 500px;
+  }
+
+  .showcase-title {
+    font-size: 96px;
+    line-height: 1;
+  }
+
+  .style-selector {
+    display: flex;
+    align-items: center;
+    gap: var(--size-8);
+    margin-top: var(--size-16);
+  }
 
   .showcase-section {
-
+    background: var(--color-background-tint);
+    border-radius: 12px;
+    padding: var(--size-32);
     margin-bottom: var(--size-48);
 
     > h2 {
+      font-family: "Geist Mono", monospace;
+      font-size: 14px;
+      font-weight: 300;
+      color: var(--color-background-dark);
       margin-bottom: var(--size-16);
-      padding-bottom: var(--size-8);
-      border-bottom: 2px solid var(--color-primary);
+      text-transform: lowercase;
     }
   }
 
-  .card-grid {
+  .mono-sample {
+    font-family: "Geist Mono", monospace;
+  }
+
+  .controls-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-48);
+  }
+
+  .controls-top {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--size-24);
+    align-items: start;
   }
 
   .form-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: var(--size-24);
+    gap: var(--size-48) var(--size-24);
+  }
 
-    .card {
-      h3 {
-        margin-bottom: var(--size-16);
-      }
-    }
+  .form-control-group h3,
+  .controls-stack h3 {
+    margin-bottom: var(--size-16);
   }
 
   .form-group {
@@ -472,11 +396,78 @@
     }
   }
 
+  .form-control-group select,
+  .form-control-group input[type="number"],
+  .form-control-group input[type="text"],
+  .form-control-group input[type="date"],
+  .form-control-group input[type="datetime-local"],
+  .form-control-group input[type="time"] {
+    font-family: "Geist", sans-serif;
+    font-size: 1rem;
+    border: 1px solid #d5d8dc;
+    box-shadow: none;
+  }
+
+  .toggle-demo {
+    display: flex;
+    align-items: center;
+    gap: var(--size-12);
+
+    span {
+      font-family: "Geist Mono", monospace;
+      font-size: 1rem;
+      color: var(--color-background-dark);
+    }
+  }
+
+  .mini-toggle-switch {
+    width: 36px;
+    height: 22px;
+    --ui-radius: 999px;
+    position: relative;
+    cursor: pointer;
+    overflow: hidden;
+    transition: background-color 0.3s ease;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.08);
+    }
+
+    &.enabled {
+      background-color: var(--color-primary);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+  }
+
+  .mini-toggle-knob {
+    width: 16px;
+    height: 16px;
+    --ui-radius: 999px;
+    --card-color: rgb(29, 29, 29);
+    background-color: var(--color-primary);
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    padding: 0;
+    transition:
+      transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+      background-color 0.3s ease;
+  }
+
+  .mini-toggle-switch.enabled .mini-toggle-knob {
+    transform: translateX(14px);
+    background-color: white;
+  }
+
   .button-row {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: var(--size-16);
-    align-items: center;
+    align-items: flex-start;
   }
 
   .color-grid {
@@ -484,6 +475,12 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: var(--size-16);
+  }
+
+  @media (max-width: 640px) {
+    .controls-top {
+      grid-template-columns: 1fr;
+    }
   }
 
   .color-swatch {
@@ -496,49 +493,21 @@
 
     span {
       font-family: "IBM Plex Mono", monospace;
-      font-size: 12px;
+      font-size: 1rem;
       font-weight: 600;
     }
 
     code {
-      font-size: 11px;
+      font-size: 1rem;
       opacity: 0.8;
     }
 
     &.primary {
-      --card-color: var(--color-primary);
-      color: white;
-    }
-    &.secondary {
-      background-color: var(--color-secondary);
+      background-color: var(--color-primary);
       color: white;
     }
     &.secondary-1 {
       background-color: var(--color-secondary-1);
-      color: white;
-    }
-    &.secondary-2 {
-      background-color: var(--color-secondary-2);
-      color: white;
-    }
-    &.secondary-3 {
-      background-color: var(--color-secondary-3);
-      color: white;
-    }
-    &.secondary-4 {
-      background-color: var(--color-secondary-4);
-      color: white;
-    }
-    &.secondary-5 {
-      background-color: var(--color-secondary-5);
-      color: white;
-    }
-    &.secondary-6 {
-      background-color: var(--color-secondary-6);
-      color: white;
-    }
-    &.secondary-7 {
-      background-color: var(--color-secondary-7);
       color: white;
     }
     &.accent {
@@ -566,6 +535,10 @@
     align-items: stretch;
   }
 
+  .card-slot-grid .card {
+    padding: var(--size-32);
+  }
+
   @media (max-width: 800px) {
     .card-slot-grid {
       grid-template-columns: 1fr;
@@ -589,48 +562,9 @@
     }
   }
 
-  .spacing-demo {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--size-24);
-    align-items: flex-end;
-  }
-
-  .spacing-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--size-8);
-  }
-
-  .spacing-box {
-    background-color: var(--color-primary);
-    border-radius: var(--size-2);
-  }
-
-  .grid-cell {
-    background-color: var(--color-primary);
-    color: white;
-    padding: var(--size-8);
-    text-align: center;
-    border-radius: var(--size-4);
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 12px;
-  }
-
-  .code-block {
-    display: block;
-    background-color: var(--color-background-tint);
-    padding: var(--size-12);
-    border-radius: var(--size-4);
-    font-size: 12px;
-    white-space: pre;
-    overflow-x: auto;
-  }
-
   .range-value {
     font-family: "IBM Plex Mono", monospace;
-    font-size: 12px;
+    font-size: 1rem;
     color: var(--color-background-dark);
   }
 

--- a/demo/svelte/src/demo/css_showcase/style.dev.scss
+++ b/demo/svelte/src/demo/css_showcase/style.dev.scss
@@ -1,0 +1,239 @@
+.css-showcase[data-showcase-style="dev"],
+.dev-style {
+  --color-primary: #000;
+  --color-secondary-1: #000;
+  --color-accent: #000;
+  --color-background: #fff;
+  --color-background-tint: #fff;
+  --color-background-dark: #000;
+  --color-text: #000;
+  --dev-border: 2px solid #000;
+
+  &,
+  * {
+    font-family: "Geist", sans-serif !important;
+    border-radius: 0 !important;
+    color: #000 !important;
+    box-shadow: none !important;
+  }
+
+  *::before,
+  *::after {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+
+  .showcase-section {
+    background: #fff !important;
+    border: var(--dev-border);
+    box-shadow: none !important;
+  }
+
+  .showcase-header {
+    background: #fff !important;
+  }
+
+  .card,
+  .slot,
+  button,
+  .button,
+  input,
+  select,
+  progress,
+  .color-swatch {
+    background: #fff !important;
+    border: var(--dev-border) !important;
+    box-shadow: none !important;
+  }
+
+  button,
+  .button,
+  input[type="number"],
+  input[type="text"],
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="time"],
+  select {
+    background: #fff !important;
+    border: var(--dev-border) !important;
+    padding: 0.5rem 0.75rem !important;
+  }
+
+  button.primary,
+  button.active,
+  .button.primary,
+  .button.active {
+    background: #000 !important;
+    color: #fff !important;
+  }
+
+  button:disabled,
+  input:disabled,
+  select:disabled {
+    background: #fff !important;
+    color: #000 !important;
+    cursor: not-allowed;
+  }
+
+  label:has(input[type="checkbox"]),
+  label:has(input[type="radio"]) {
+    gap: 0.5rem;
+  }
+
+  label:has(input[type="checkbox"]) input + span,
+  label:has(input[type="radio"]) input + span {
+    width: 1rem !important;
+    height: 1rem !important;
+    background: #fff !important;
+    border: var(--dev-border) !important;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    transform: none !important;
+    perspective: none !important;
+  }
+
+  label:has(input[type="checkbox"]) input + span::before,
+  label:has(input[type="radio"]) input + span::before,
+  label:has(input[type="checkbox"]) input + span::after,
+  label:has(input[type="radio"]) input + span::after {
+    background: transparent !important;
+    border: 0 !important;
+    width: auto !important;
+    height: auto !important;
+    left: auto !important;
+    top: auto !important;
+    transform: none !important;
+    transition: none !important;
+  }
+
+  label:has(input[type="checkbox"]:checked) input + span::after {
+    content: "x" !important;
+    color: #000 !important;
+    font-size: 1rem !important;
+    line-height: 1 !important;
+  }
+
+  label:has(input[type="radio"]:checked) input + span::after {
+    content: "" !important;
+    width: 0.5rem !important;
+    height: 0.5rem !important;
+    background: #000 !important;
+  }
+
+  input[type="range"] {
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    height: 0.5rem !important;
+    background: #fff !important;
+    border: var(--dev-border) !important;
+    padding: 0 !important;
+  }
+
+  input[type="range"]::-webkit-slider-runnable-track {
+    height: 0.5rem !important;
+    background: #fff !important;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none !important;
+    appearance: none !important;
+    width: 1rem !important;
+    height: 1rem !important;
+    background: #000 !important;
+    border: var(--dev-border) !important;
+    margin-top: -0.25rem !important;
+    box-shadow: none !important;
+  }
+
+  input[type="range"]::-moz-range-track {
+    height: 0.5rem !important;
+    background: #fff !important;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  input[type="range"]::-moz-range-thumb {
+    width: 1rem !important;
+    height: 1rem !important;
+    background: #000 !important;
+    border: var(--dev-border) !important;
+    box-shadow: none !important;
+  }
+
+  input[type="range"]::-moz-range-progress {
+    height: 0.5rem !important;
+    background: #000 !important;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  .mini-toggle-switch {
+    width: 2.25rem !important;
+    height: 1.25rem !important;
+    background: #fff !important;
+    border: var(--dev-border) !important;
+  }
+
+  .mini-toggle-knob {
+    width: 0.75rem !important;
+    height: 0.75rem !important;
+    background: #000 !important;
+    top: calc(0.25rem - 1px) !important;
+    left: calc(0.25rem - 1px) !important;
+  }
+
+  .mini-toggle-switch.enabled .mini-toggle-knob {
+    transform: translateX(1rem) !important;
+    background: #000 !important;
+  }
+
+  .card::before,
+  .card::after,
+  button::after,
+  .button::after {
+    display: none !important;
+  }
+
+  .color-swatch,
+  .color-swatch span,
+  .color-swatch code {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  .mini-toggle-switch.enabled,
+  .mini-toggle-knob,
+  .mini-toggle-switch.enabled .mini-toggle-knob,
+  progress::-webkit-progress-value,
+  progress::-moz-progress-bar {
+    background: #000 !important;
+    background-color: #000 !important;
+  }
+
+  progress::-webkit-progress-bar {
+    background: #fff !important;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  progress::-webkit-progress-value {
+    background: #000 !important;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  progress::-moz-progress-bar {
+    background: #000 !important;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  progress:indeterminate {
+    background: linear-gradient(90deg, #fff 0%, #000 50%, #fff 100%) !important;
+    background-size: 200% 100% !important;
+  }
+}

--- a/demo/svelte/src/demo/drag_drop/DragDropDemo.svelte
+++ b/demo/svelte/src/demo/drag_drop/DragDropDemo.svelte
@@ -18,6 +18,7 @@
         { id: "containers", label: "Containers" },
         { id: "drop-index", label: "Drop Index" },
         { id: "drop-layout", label: "Drop: Virtual Layout" },
+        { id: "drop-snapshot", label: "Drop: Snapshot" },
         { id: "drop-collisions", label: "Drop: Collisions" },
         { id: "drop-candidates", label: "Drop: Candidates" },
         { id: "drop-neighbors", label: "Drop: Neighbors (prev/next)" },

--- a/demo/svelte/src/demo/drop_snap_nested/DropSnapNestedDemo.svelte
+++ b/demo/svelte/src/demo/drop_snap_nested/DropSnapNestedDemo.svelte
@@ -1,0 +1,474 @@
+<script lang="ts">
+  import { Engine } from "@snap-engine/asset-base-svelte";
+  import { Item, ItemContainer as Container } from "@snap-engine/snapsort-svelte";
+  import type { Engine as EngineClass } from "@snap-engine/core";
+
+  let engineInstance: EngineClass | null = $state(null);
+  let debugMode = $state(false);
+  let devStyleLoaded = false;
+
+  const DEBUG_TAGS = [
+    { id: "grid", label: "Grid" },
+    { id: "hitboxes", label: "Hitboxes" },
+    { id: "dom-read-1", label: "DOM Read 1" },
+    { id: "dom-read-2", label: "DOM Read 2" },
+    { id: "dom-read-3", label: "DOM Read 3" },
+    { id: "rows", label: "Rows" },
+    { id: "item-positions", label: "Item Positions" },
+    { id: "containers", label: "Containers" },
+    { id: "drop-index", label: "Drop Index" },
+    { id: "drop-layout", label: "Drop Layout" },
+    { id: "drop-snapshot", label: "Drop Snapshot" },
+    { id: "drop-collisions", label: "Drop Collisions" },
+    { id: "drop-candidates", label: "Drop Candidates" },
+    { id: "drop-neighbors", label: "Drop Neighbors" },
+    { id: "drop-tiebreak", label: "Drop Tie-break" },
+    { id: "drop-zones", label: "Drop Zones" },
+    { id: "collisions", label: "Collisions" },
+    { id: "animations", label: "Animations" },
+  ] as const;
+
+  let enabledTags = $state<Record<string, boolean>>(
+    Object.fromEntries(DEBUG_TAGS.map((tag) => [tag.id, tag.id.startsWith("drop-")])),
+  );
+
+  function applyTagFilter() {
+    const renderer = engineInstance?.debugRenderer;
+    if (!renderer) return;
+
+    const allEnabled = DEBUG_TAGS.every((tag) => enabledTags[tag.id]);
+    renderer.enabledTags = allEnabled
+      ? null
+      : new Set(DEBUG_TAGS.filter((tag) => enabledTags[tag.id]).map((tag) => tag.id));
+  }
+
+  function onTagChange(id: string) {
+    enabledTags[id] = !enabledTags[id];
+    applyTagFilter();
+  }
+
+  function toggleAll(on: boolean) {
+    for (const tag of DEBUG_TAGS) {
+      enabledTags[tag.id] = on;
+    }
+    applyTagFilter();
+  }
+
+  export function setDebug(enabled: boolean) {
+    debugMode = enabled;
+  }
+
+  $effect(() => {
+    if (!devStyleLoaded) {
+      devStyleLoaded = true;
+      import("../css_showcase/style.dev.scss");
+    }
+  });
+
+  $effect(() => {
+    if (engineInstance) {
+      applyTagFilter();
+    }
+  });
+</script>
+
+<div class="snapsort-demo dev-style">
+  <h1>SnapSort</h1>
+
+  <div class="snapsort-shell">
+    <div class="engine-area">
+      <Engine id="snapsort-combined-demo-canvas" debug={debugMode} bind:engine={engineInstance}>
+        <div class="demo-grid">
+          <article class="demo-cell">
+            <h2>Vertical Column</h2>
+            <Container config={{ direction: "column", groupID: "vertical-group" }}>
+              <Item className="demo-item"><p>Item 1</p></Item>
+              <Item className="demo-item"><p>Item 2</p></Item>
+              <Item className="demo-item"><p>Item 3</p></Item>
+              <Item className="demo-item"><p>Item 4</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Horizontal Row</h2>
+            <Container config={{ direction: "row", groupID: "horizontal-group" }}>
+              <Item className="demo-item"><p>Item 1</p></Item>
+              <Item className="demo-item"><p>Item 2</p></Item>
+              <Item className="demo-item"><p>Item 3</p></Item>
+              <Item className="demo-item"><p>Item 4</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell wide">
+            <h2>Wrapping Row</h2>
+            <Container config={{ direction: "row", groupID: "wrap-row" }} locked={true}>
+              {#each Array.from({ length: 12 }, (_, index) => index + 1) as n}
+                <Item className="demo-item row-item"><p>W{n}</p></Item>
+              {/each}
+            </Container>
+          </article>
+
+          <article class="demo-cell wide">
+            <h2>Horizontal Double Row</h2>
+            <Container config={{ direction: "row", groupID: "double-row-group" }}>
+              {#each Array.from({ length: 28 }, (_, index) => index + 1) as n}
+                <Item className="demo-item row-item"><p>Item {n}</p></Item>
+              {/each}
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Different Sizes</h2>
+            <Container config={{ direction: "row", groupID: "sizes-group" }}>
+              <Item className="demo-item"><p style="width: 60px;">Small</p></Item>
+              <Item className="demo-item"><p style="width: 100px;">Medium</p></Item>
+              <Item className="demo-item"><p style="width: 140px;">Large</p></Item>
+              <Item className="demo-item"><p style="width: 60px;">Tall</p></Item>
+              <Item className="demo-item"><p style="width: 30px;">Short</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Flat List</h2>
+            <Container config={{ direction: "column", groupID: "flat-group" }} locked={true}>
+              <Item className="demo-item"><p>Item A</p></Item>
+              <Item className="demo-item"><p>Item B</p></Item>
+              <Item className="demo-item"><p>Item C</p></Item>
+              <Item className="demo-item"><p>Item D</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Multiple Drop Areas</h2>
+            <Container config={{ direction: "row", name: "multi-root", noDrop: true }} locked={true}>
+              <Container config={{ direction: "column", name: "multi-area-1" }} locked={true}>
+                <h3>Area 1</h3>
+                <Item className="demo-item"><p>Item A</p></Item>
+                <Item className="demo-item"><p>Item B</p></Item>
+                <Item className="demo-item"><p>Item C</p></Item>
+              </Container>
+              <Container config={{ direction: "column", name: "multi-area-2" }} locked={true}>
+                <h3>Area 2</h3>
+                <Item className="demo-item"><p>Item X</p></Item>
+                <Item className="demo-item"><p>Item Y</p></Item>
+                <Item className="demo-item"><p>Item Z</p></Item>
+              </Container>
+            </Container>
+          </article>
+
+          <article class="demo-cell wide">
+            <h2>Multiple Drop Areas Row</h2>
+            <Container config={{ direction: "column", name: "multi-row-root" }} locked={true}>
+              <h3>Area 1</h3>
+              <Container config={{ direction: "row", name: "multi-row-area-1" }} locked={true}>
+                <Item className="demo-item"><p>Item A</p></Item>
+                <Item className="demo-item"><p>Item B</p></Item>
+                <Item className="demo-item"><p>Item C</p></Item>
+              </Container>
+              <h3>Area 2</h3>
+              <Container config={{ direction: "row", name: "multi-row-area-2" }} locked={true}>
+                <Item className="demo-item"><p>Item X</p></Item>
+                <Item className="demo-item"><p>Item Y</p></Item>
+                <Item className="demo-item"><p>Item Z</p></Item>
+              </Container>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Nested Container</h2>
+            <Container config={{ direction: "column", groupID: "nested-group" }} locked={true}>
+              <Item className="demo-item"><p>Item 1</p></Item>
+              <Item className="demo-item"><p>Item 1.5</p></Item>
+              <Container config={{ direction: "column", groupID: "nested-group" }} locked={false}>
+                <Item className="demo-item sub-item"><p>Sub A1</p></Item>
+                <Item className="demo-item sub-item"><p>Sub A2</p></Item>
+                <Item className="demo-item sub-item"><p>Sub A3</p></Item>
+              </Container>
+              <Item className="demo-item"><p>Item 2</p></Item>
+              <Item className="demo-item"><p>Item 3</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Draggable Sub-Containers</h2>
+            <Container config={{ direction: "column", groupID: "drag-nested-group" }} locked={true}>
+              <Container config={{ direction: "column", groupID: "drag-nested-group" }} locked={false}>
+                <Item className="demo-item sub-item"><p>Group 1 - A</p></Item>
+                <Item className="demo-item sub-item"><p>Group 1 - B</p></Item>
+              </Container>
+              <Container config={{ direction: "column", groupID: "drag-nested-group" }} locked={false}>
+                <Item className="demo-item sub-item"><p>Group 2 - A</p></Item>
+                <Item className="demo-item sub-item"><p>Group 2 - B</p></Item>
+                <Item className="demo-item sub-item"><p>Group 2 - C</p></Item>
+              </Container>
+              <Item className="demo-item"><p>Loose Item</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Nested Row Groups</h2>
+            <Container config={{ direction: "row", groupID: "nested-row-group" }} locked={true}>
+              <Item className="demo-item row-item"><p>R1</p></Item>
+              <Container config={{ direction: "row", groupID: "nested-row-group" }} locked={false}>
+                <Item className="demo-item row-item sub-item"><p>S1</p></Item>
+                <Item className="demo-item row-item sub-item"><p>S2</p></Item>
+                <Item className="demo-item row-item sub-item"><p>S3</p></Item>
+              </Container>
+              <Item className="demo-item row-item"><p>R2</p></Item>
+              <Item className="demo-item row-item"><p>R3</p></Item>
+            </Container>
+          </article>
+
+          <article class="demo-cell">
+            <h2>Layers Panel</h2>
+            <Container config={{ direction: "column", groupID: "layers" }} locked={true}>
+              <Item className="layer-item">
+                <div class="layer-row">
+                  <span class="layer-icon">&#x25FB;</span>
+                  <span>Header</span>
+                </div>
+              </Item>
+              <Container config={{ direction: "column", groupID: "layers" }} locked={false}>
+                <div class="group-label">Hero Section</div>
+                <Item className="layer-item">
+                  <div class="layer-row">
+                    <span class="layer-icon">&#x25CB;</span>
+                    <span>Avatar</span>
+                  </div>
+                </Item>
+                <Item className="layer-item">
+                  <div class="layer-row">
+                    <span class="layer-icon">T</span>
+                    <span>Title</span>
+                  </div>
+                </Item>
+                <Item className="layer-item">
+                  <div class="layer-row">
+                    <span class="layer-icon">T</span>
+                    <span>Subtitle</span>
+                  </div>
+                </Item>
+              </Container>
+              <Item className="layer-item">
+                <div class="layer-row">
+                  <span class="layer-icon">&#x25FB;</span>
+                  <span>Card Grid</span>
+                </div>
+              </Item>
+              <Item className="layer-item">
+                <div class="layer-row">
+                  <span class="layer-icon">&#x25FB;</span>
+                  <span>Footer</span>
+                </div>
+              </Item>
+            </Container>
+          </article>
+        </div>
+      </Engine>
+    </div>
+
+    {#if debugMode}
+      <aside class="debug-sidebar">
+        <div class="debug-sidebar-header">
+          <h2>Debug Tags</h2>
+          <div class="debug-sidebar-actions">
+            <button onclick={() => toggleAll(true)}>All</button>
+            <button onclick={() => toggleAll(false)}>None</button>
+          </div>
+        </div>
+        {#each DEBUG_TAGS as tag}
+          <label class="debug-tag-item">
+            <input type="checkbox" checked={enabledTags[tag.id]} onchange={() => onTagChange(tag.id)} />
+            <span></span>
+            {tag.label}
+          </label>
+        {/each}
+      </aside>
+    {/if}
+  </div>
+</div>
+
+<style lang="scss">
+  .snapsort-demo {
+    width: 100%;
+    min-height: 100%;
+    overflow: visible;
+    background: #fff;
+    box-sizing: border-box;
+    padding: var(--size-24);
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-24);
+  }
+
+  h1 {
+    margin: 0;
+    font-family: "Geist", sans-serif;
+    font-size: 72px;
+    line-height: 1;
+    color: #000;
+  }
+
+  .snapsort-shell {
+    display: flex;
+    align-items: stretch;
+    gap: var(--size-24);
+  }
+
+  .engine-area {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .demo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--size-24);
+    align-items: start;
+    pointer-events: auto;
+  }
+
+  .demo-cell {
+    min-height: 240px;
+    border: 2px solid #000;
+    background: #fff;
+    box-sizing: border-box;
+    padding: var(--size-16);
+  }
+
+  .demo-cell.wide {
+    grid-column: span 2;
+  }
+
+  h2 {
+    margin: 0 0 var(--size-16);
+    font-family: "Geist", sans-serif;
+    font-size: 24px;
+    font-weight: 500;
+    color: #000;
+  }
+
+  h3 {
+    margin: var(--size-8) 0;
+    font-family: "Geist", sans-serif;
+    font-size: 16px;
+    font-weight: 500;
+    color: #000;
+  }
+
+  :global(.snapsort-container) {
+    gap: var(--size-8);
+    min-height: 40px;
+  }
+
+  :global(.snapsort-container .snapsort-container) {
+    border: 2px solid #000;
+    padding: var(--size-8);
+  }
+
+  :global(.demo-item),
+  :global(.layer-item),
+  :global(.snapsort-item) {
+    margin: var(--size-4);
+    border: 2px solid #000;
+    background: #fff;
+    cursor: grab;
+    box-sizing: border-box;
+  }
+
+  :global(.demo-item:active),
+  :global(.layer-item:active),
+  :global(.snapsort-item:active) {
+    cursor: grabbing;
+  }
+
+  :global(.demo-item p) {
+    margin: 0;
+    padding: var(--size-8) var(--size-12);
+    font-size: 1rem;
+    user-select: none;
+  }
+
+  :global(.demo-item.row-item) {
+    min-width: 50px;
+    text-align: center;
+  }
+
+  :global(.demo-item.sub-item) {
+    opacity: 0.6;
+  }
+
+  :global(.ghost) {
+    background: #e5e5e5;
+    border: 2px solid #9a9a9a;
+    box-sizing: border-box;
+    opacity: 1;
+  }
+
+  .layer-row {
+    display: flex;
+    align-items: center;
+    gap: var(--size-8);
+    padding: var(--size-8) var(--size-12);
+    user-select: none;
+    font-size: 1rem;
+  }
+
+  .layer-icon {
+    width: var(--size-16);
+    text-align: center;
+  }
+
+  .group-label {
+    padding: var(--size-8) var(--size-12);
+    font-size: 1rem;
+    font-weight: 500;
+    border-bottom: 2px solid #000;
+  }
+
+  .debug-sidebar {
+    width: 260px;
+    flex-shrink: 0;
+    background: #fff;
+    border: 2px solid #000;
+    padding: var(--size-16);
+    box-sizing: border-box;
+    pointer-events: auto;
+  }
+
+  .debug-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--size-12);
+    margin-bottom: var(--size-16);
+  }
+
+  .debug-sidebar-actions {
+    display: flex;
+    gap: var(--size-8);
+  }
+
+  .debug-tag-item {
+    display: flex;
+    align-items: center;
+    gap: var(--size-8);
+    padding: var(--size-4) 0;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  @media (max-width: 900px) {
+    .snapsort-shell {
+      flex-direction: column;
+    }
+
+    .demo-cell.wide {
+      grid-column: auto;
+    }
+
+    .debug-sidebar {
+      width: 100%;
+    }
+  }
+</style>

--- a/demo/svelte/src/demo/nested_items/NestedItemsDemo.svelte
+++ b/demo/svelte/src/demo/nested_items/NestedItemsDemo.svelte
@@ -18,6 +18,7 @@
         { id: "containers", label: "Containers" },
         { id: "drop-index", label: "Drop Index" },
         { id: "drop-layout", label: "Drop: Virtual Layout" },
+        { id: "drop-snapshot", label: "Drop: Snapshot" },
         { id: "drop-collisions", label: "Drop: Collisions" },
         { id: "drop-candidates", label: "Drop: Candidates" },
         { id: "drop-neighbors", label: "Drop: Neighbors (prev/next)" },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "server:svelte": "FRAMEWORK=svelte vite serve demo/svelte --config demo/svelte/vite.config.mjs --host",
     "dev:all": "concurrently --kill-others \"npm run dev:vanilla\" \"npm run dev:react\"",
     "test": "start-server-and-test server:vanilla http://localhost:3001 'playwright test'",
+    "test:snapsort": "playwright test -c tests/e2e/snapsort.playwright.config.ts",
     "test:ui": "start-server-and-test server:vanilla http://localhost:3001 'playwright test --ui'",
     "format": "prettier --write src",
     "lint": "eslint src --ext .ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   pinchEndProp,
   mouseButtonBitmap,
 } from "./input";
-import { getDomProperty, EventProxyFactory } from "./util";
+import { getDomProperty, cloneDomProperty, EventProxyFactory } from "./util";
 import { Camera } from "./camera";
 
 export {
@@ -26,6 +26,7 @@ export {
   GlobalManager,
   Camera,
   getDomProperty,
+  cloneDomProperty,
   EventProxyFactory,
   type pointerDownProp,
   type pointerMoveProp,

--- a/src/object.ts
+++ b/src/object.ts
@@ -4,6 +4,7 @@ import {
   EventProxyFactory,
   generateTransformString,
   parseTransformString,
+  cloneDomProperty,
 } from "./util";
 import { Collider } from "./collision";
 import { getDomProperty } from "./util";
@@ -767,6 +768,12 @@ export interface DomProperty extends TransformProperty {
     bottom: number;
     left: number;
   };
+  border: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  };
 }
 
 export interface DomInsertMode {
@@ -829,6 +836,12 @@ export class DomElement {
         left: 0,
       },
       padding: {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      },
+      border: {
         top: 0,
         right: 0,
         bottom: 0,
@@ -925,6 +938,7 @@ export class DomElement {
     this.property.screenY = property.screenY;
     this.property.margin = property.margin;
     this.property.padding = property.padding;
+    this.property.border = property.border;
   }
 
   /**
@@ -1113,6 +1127,12 @@ export class ElementObject extends BaseObject {
           bottom: 0,
           left: 0,
         },
+        border: {
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+        },
       });
     }
     this.transformMode = "direct";
@@ -1155,7 +1175,10 @@ export class ElementObject extends BaseObject {
   ): void {
     const fromIndex = fromStage == "READ_1" ? 0 : fromStage == "READ_2" ? 1 : 2;
     const toIndex = toStage == "READ_1" ? 0 : toStage == "READ_2" ? 1 : 2;
-    Object.assign(this._domProperty[toIndex], this._domProperty[fromIndex]);
+    Object.assign(
+      this._domProperty[toIndex],
+      cloneDomProperty(this._domProperty[fromIndex]),
+    );
   }
 
   /**
@@ -1241,11 +1264,11 @@ export class ElementObject extends BaseObject {
     this._dom.readDom(subtractAppliedTransform);
     super.readDom(subtractAppliedTransform);
     if (currentStage == "READ_1") {
-      Object.assign(this._domProperty[0], this._dom.property);
+      Object.assign(this._domProperty[0], cloneDomProperty(this._dom.property));
     } else if (currentStage == "READ_2") {
-      Object.assign(this._domProperty[1], this._dom.property);
+      Object.assign(this._domProperty[1], cloneDomProperty(this._dom.property));
     } else if (currentStage == "READ_3") {
-      Object.assign(this._domProperty[2], this._dom.property);
+      Object.assign(this._domProperty[2], cloneDomProperty(this._dom.property));
     }
     this.event.dom.onAfterReadDom?.(
       currentStage as "READ_1" | "READ_2" | "READ_3",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { TransformProperty } from "./object";
+import type { DomProperty, TransformProperty } from "./object";
 
 /**
  * Retrieves the position and dimensions of a DOM element in multiple coordinate spaces.
@@ -28,6 +28,10 @@ function getDomProperty(engine: any, dom: HTMLElement) {
   const padding_right = parseFloat(css.paddingRight) || 0;
   const padding_bottom = parseFloat(css.paddingBottom) || 0;
   const padding_left = parseFloat(css.paddingLeft) || 0;
+  const border_top = parseFloat(css.borderTopWidth) || 0;
+  const border_right = parseFloat(css.borderRightWidth) || 0;
+  const border_bottom = parseFloat(css.borderBottomWidth) || 0;
+  const border_left = parseFloat(css.borderLeftWidth) || 0;
 
   if (engine == null || engine.camera == null) {
     return {
@@ -50,6 +54,12 @@ function getDomProperty(engine: any, dom: HTMLElement) {
         right: padding_right,
         bottom: padding_bottom,
         left: padding_left,
+      },
+      border: {
+        top: border_top,
+        right: border_right,
+        bottom: border_bottom,
+        left: border_left,
       },
     };
   }
@@ -85,6 +95,12 @@ function getDomProperty(engine: any, dom: HTMLElement) {
       right: padding_right,
       bottom: padding_bottom,
       left: padding_left,
+    },
+    border: {
+      top: border_top,
+      right: border_right,
+      bottom: border_bottom,
+      left: border_left,
     },
   };
 }
@@ -238,10 +254,27 @@ function EventProxyFactory<BindObject, Callback extends object>(
   });
 }
 
+function cloneDomProperty(prop: DomProperty): DomProperty {
+  return {
+    x: prop.x,
+    y: prop.y,
+    height: prop.height,
+    width: prop.width,
+    scaleX: prop.scaleX,
+    scaleY: prop.scaleY,
+    screenX: prop.screenX,
+    screenY: prop.screenY,
+    margin: { ...prop.margin },
+    padding: { ...prop.padding },
+    border: { ...prop.border },
+  };
+}
+
 export {
   setDomStyle,
   EventProxyFactory,
   getDomProperty,
+  cloneDomProperty,
   generateTransformString,
   parseTransformString,
 };

--- a/tests/e2e/snapsort-drag-snapshot.spec.ts
+++ b/tests/e2e/snapsort-drag-snapshot.spec.ts
@@ -566,6 +566,51 @@ test.describe("Snapsort drag-start snapshot layout", () => {
     ).toHaveLength(0);
   });
 
+  test("animates displaced items when the ghost reorders", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const verticalColumn = await demoBoxByHeading(page, "Vertical Column");
+    const item1 = await itemByTextIn(verticalColumn, "Item 1");
+    const item4 = await itemByTextIn(verticalColumn, "Item 4");
+    const item1Center = center(await itemRect(item1));
+    const item4Center = center(await itemRect(item4));
+
+    await page.mouse.move(item1Center.x, item1Center.y);
+    await page.mouse.down();
+    await page.mouse.move(item1Center.x, item4Center.y, { steps: 12 });
+
+    const animated = await page.waitForFunction(() => {
+      const items = [...document.querySelectorAll(".snapsort-item")].filter(
+        (element) =>
+          element.id !== "spacer" &&
+          !/Item 1/.test(element.textContent ?? ""),
+      );
+      return items.some((element) =>
+        /^translate3d\(/.test((element as HTMLElement).style.transform),
+      );
+    });
+    await page.mouse.up();
+    await page.waitForTimeout(120);
+
+    await writeJson(testInfo.outputPath("reorder-animation-trace.json"), {
+      animated: await animated.jsonValue(),
+      errors: consoleMessages.filter((message) =>
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+      ),
+    });
+
+    expect(await animated.jsonValue()).toBe(true);
+    expect(
+      consoleMessages.filter((message) =>
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+      ),
+    ).toHaveLength(0);
+  });
+
   test("does not flicker the spacer backward while dragging down a vertical column", async ({
     page,
   }, testInfo) => {

--- a/tests/e2e/snapsort-drag-snapshot.spec.ts
+++ b/tests/e2e/snapsort-drag-snapshot.spec.ts
@@ -1,8 +1,43 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import {
+  contentBoxOrigin,
+  flowLayoutPositions,
+  type LayoutNode,
+} from "../../assets/snapsort/core/src/layout_engine";
 
 type Rect = { x: number; y: number; width: number; height: number };
+type Box = Rect & {
+  scaleX: number;
+  scaleY: number;
+  screenX: number;
+  screenY: number;
+  margin: { top: number; right: number; bottom: number; left: number };
+  padding: { top: number; right: number; bottom: number; left: number };
+  border: { top: number; right: number; bottom: number; left: number };
+};
+
+type LayoutCase = {
+  name: string;
+  width: number;
+  padding: { top: number; right: number; bottom: number; left: number };
+  border: { top: number; right: number; bottom: number; left: number };
+  columnGap: number;
+  rowGap: number;
+  itemWidths: number[];
+  itemHeights: number[];
+  itemBorders: number[];
+};
+
+type BrowserLayoutCase = {
+  name: string;
+  container: Box;
+  items: Array<{ id: string; box: Box }>;
+  draggedId: string;
+  ghost: { width: number; height: number };
+  actualGhosts: Array<{ index: number; x: number; y: number }>;
+};
 
 type DragSample = {
   step: number;
@@ -34,7 +69,12 @@ async function installSnapsortTrace(page: Page) {
     const win = window as unknown as {
       __snapsortTrace: {
         dom: DomTraceEntry[];
-        mutations: Array<{ type: string; target: string; attr: string | null; time: number }>;
+        mutations: Array<{
+          type: string;
+          target: string;
+          attr: string | null;
+          time: number;
+        }>;
       };
       __snapsortActiveText?: string;
       __snapsortActiveIndex?: number;
@@ -138,6 +178,224 @@ function center(rect: Rect) {
   };
 }
 
+function horizontalDoubleRowLayoutCases(): LayoutCase[] {
+  const cases: LayoutCase[] = [];
+  for (let width = 236; width <= 356; width += 4) {
+    const seed = width * 17;
+    const count = 14 + (width % 5);
+    const itemWidths = Array.from({ length: count }, (_, index) => {
+      return 42 + ((seed + index * 13) % 42);
+    });
+    const itemHeights = Array.from({ length: count }, (_, index) => {
+      return 30 + ((seed + index * 7) % 16);
+    });
+    const itemBorders = Array.from({ length: count }, (_, index) => {
+      return (seed + index * 3) % 4;
+    });
+    cases.push({
+      name: `w${width}`,
+      width,
+      padding: {
+        top: (seed % 9) + 1,
+        right: ((seed >> 1) % 13) + 2,
+        bottom: ((seed >> 2) % 7) + 1,
+        left: ((seed >> 3) % 11) + 2,
+      },
+      border: {
+        top: seed % 5,
+        right: (seed + 1) % 6,
+        bottom: (seed + 2) % 5,
+        left: (seed + 3) % 6,
+      },
+      columnGap: 4 + (seed % 8),
+      rowGap: 3 + ((seed >> 2) % 9),
+      itemWidths,
+      itemHeights,
+      itemBorders,
+    });
+  }
+  return cases;
+}
+
+function layoutNodeFromBrowserCase(
+  browserCase: BrowserLayoutCase,
+): LayoutNode<string> {
+  return {
+    value: "container",
+    direction: "row",
+    locked: false,
+    isGhost: false,
+    box: browserCase.container,
+    children: browserCase.items.map((item) => ({
+      value: item.id,
+      direction: "column",
+      locked: false,
+      isGhost: false,
+      box: item.box,
+      children: [],
+    })),
+  };
+}
+
+async function measureBrowserLayoutCases(
+  page: Page,
+  cases: LayoutCase[],
+): Promise<BrowserLayoutCase[]> {
+  await page.setContent('<main id="layout-fixture"></main>');
+  return page.evaluate((layoutCases) => {
+    type BrowserBox = Box;
+    type BrowserCase = BrowserLayoutCase;
+    const fixture = document.querySelector("#layout-fixture") as HTMLElement;
+    const px = (value: number) => `${value}px`;
+    const sideCss = (value: {
+      top: number;
+      right: number;
+      bottom: number;
+      left: number;
+    }) =>
+      `${px(value.top)} ${px(value.right)} ${px(value.bottom)} ${px(value.left)}`;
+    const boxOf = (element: HTMLElement): BrowserBox => {
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      const number = (value: string) => parseFloat(value) || 0;
+      return {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+        scaleX: 1,
+        scaleY: 1,
+        screenX: rect.x,
+        screenY: rect.y,
+        margin: {
+          top: number(style.marginTop),
+          right: number(style.marginRight),
+          bottom: number(style.marginBottom),
+          left: number(style.marginLeft),
+        },
+        padding: {
+          top: number(style.paddingTop),
+          right: number(style.paddingRight),
+          bottom: number(style.paddingBottom),
+          left: number(style.paddingLeft),
+        },
+        border: {
+          top: number(style.borderTopWidth),
+          right: number(style.borderRightWidth),
+          bottom: number(style.borderBottomWidth),
+          left: number(style.borderLeftWidth),
+        },
+      };
+    };
+    const makeItem = (
+      id: string,
+      width: number,
+      height: number,
+      border: number,
+      isGhost = false,
+    ) => {
+      const item = document.createElement("div");
+      item.dataset.itemId = id;
+      item.textContent = id;
+      item.style.boxSizing = "border-box";
+      item.style.flex = "0 0 auto";
+      item.style.width = px(width);
+      item.style.height = px(height);
+      item.style.border = `${px(border)} solid ${isGhost ? "#b45309" : "#2563eb"}`;
+      item.style.padding = `${px((width + height) % 5)} ${px((width + border) % 7)}`;
+      item.style.background = isGhost ? "#fef3c7" : "#dbeafe";
+      return item;
+    };
+    const buildContainer = (entry: LayoutCase) => {
+      fixture.innerHTML = "";
+      const container = document.createElement("section");
+      container.style.boxSizing = "border-box";
+      container.style.display = "flex";
+      container.style.flexDirection = "row";
+      container.style.flexWrap = "wrap";
+      container.style.alignItems = "flex-start";
+      container.style.alignContent = "flex-start";
+      container.style.width = px(entry.width);
+      container.style.padding = sideCss(entry.padding);
+      container.style.borderStyle = "solid";
+      container.style.borderColor = "#111827";
+      container.style.borderWidth = sideCss(entry.border);
+      container.style.columnGap = px(entry.columnGap);
+      container.style.rowGap = px(entry.rowGap);
+      container.style.margin = "16px";
+      fixture.appendChild(container);
+      return container;
+    };
+
+    return layoutCases.map((entry) => {
+      const draggedIndex = Math.min(3, entry.itemWidths.length - 1);
+      const draggedId = `item-${draggedIndex}`;
+      let container = buildContainer(entry);
+      const itemElements = entry.itemWidths.map((width, index) => {
+        const item = makeItem(
+          `item-${index}`,
+          width,
+          entry.itemHeights[index],
+          entry.itemBorders[index],
+        );
+        container.appendChild(item);
+        return item;
+      });
+      const containerBox = boxOf(container);
+      const items = itemElements.map((item) => ({
+        id: item.dataset.itemId!,
+        box: boxOf(item),
+      }));
+      const dragged = items[draggedIndex];
+      const remaining = items.filter((item) => item.id !== draggedId);
+      const actualGhosts: BrowserCase["actualGhosts"] = [];
+
+      for (let index = 0; index <= remaining.length; index++) {
+        container = buildContainer(entry);
+        for (let i = 0; i <= remaining.length; i++) {
+          if (i === index) {
+            container.appendChild(
+              makeItem(
+                "ghost",
+                dragged.box.width,
+                dragged.box.height,
+                entry.itemBorders[draggedIndex],
+                true,
+              ),
+            );
+          }
+          const remainingItem = remaining[i];
+          if (remainingItem) {
+            const originalIndex = Number(remainingItem.id.replace("item-", ""));
+            container.appendChild(
+              makeItem(
+                remainingItem.id,
+                entry.itemWidths[originalIndex],
+                entry.itemHeights[originalIndex],
+                entry.itemBorders[originalIndex],
+              ),
+            );
+          }
+        }
+        const ghost = container.querySelector(
+          '[data-item-id="ghost"]',
+        ) as HTMLElement;
+        const rect = ghost.getBoundingClientRect();
+        actualGhosts.push({ index, x: rect.x, y: rect.y });
+      }
+
+      return {
+        name: entry.name,
+        container: containerBox,
+        items,
+        draggedId,
+        ghost: { width: dragged.box.width, height: dragged.box.height },
+        actualGhosts,
+      };
+    });
+  }, cases);
+}
+
 async function itemRect(item: Locator): Promise<Rect> {
   await item.scrollIntoViewIfNeeded();
   const box = await item.boundingBox();
@@ -221,7 +479,9 @@ async function collectSample(
       const directSiblingTexts = spacerParent
         ? [...spacerParent.children]
             .filter((child) => child.id !== "spacer")
-            .map((child) => child.textContent?.trim().replace(/\s+/g, " ") ?? "")
+            .map(
+              (child) => child.textContent?.trim().replace(/\s+/g, " ") ?? "",
+            )
         : [];
       const parentText = directSiblingTexts.join(" | ");
       const spacerParentKind =
@@ -229,9 +489,13 @@ async function collectSample(
           ? null
           : directSiblingTexts.every((text) => /^Sub A\d/.test(text))
             ? "nested-inner"
-            : directSiblingTexts.some((text) => /Item 1\.5|Item 2|Item 3/.test(text))
+            : directSiblingTexts.some((text) =>
+                  /Item 1\.5|Item 2|Item 3/.test(text),
+                )
               ? "nested-outer"
-              : directSiblingTexts.some((text) => /Header|Card Grid|Footer/.test(text))
+              : directSiblingTexts.some((text) =>
+                    /Header|Card Grid|Footer/.test(text),
+                  )
                 ? "layers-root"
                 : directSiblingTexts.some((text) => /Hero Section/.test(text))
                   ? "layers-hero"
@@ -239,9 +503,11 @@ async function collectSample(
                     ? "drag-root"
                     : directSiblingTexts.some((text) => /Group 1 -/.test(text))
                       ? "drag-group-1"
-                      : directSiblingTexts.some((text) => /Group 2 -/.test(text))
+                      : directSiblingTexts.some((text) =>
+                            /Group 2 -/.test(text),
+                          )
                         ? "drag-group-2"
-              : "other";
+                        : "other";
       const draggedRect = rectOf(draggedElement);
       const dragged = draggedRect
         ? {
@@ -264,11 +530,16 @@ async function collectSample(
             ? describedRectOf(spacerSiblings[spacerSiblingIndex - 1])
             : null,
         spacerNext:
-          spacerSiblingIndex >= 0 && spacerSiblingIndex < spacerSiblings.length - 1
+          spacerSiblingIndex >= 0 &&
+          spacerSiblingIndex < spacerSiblings.length - 1
             ? describedRectOf(spacerSiblings[spacerSiblingIndex + 1])
             : null,
-        spacerDomPrevious: describedRectOf(spacerElement?.previousElementSibling ?? null),
-        spacerDomNext: describedRectOf(spacerElement?.nextElementSibling ?? null),
+        spacerDomPrevious: describedRectOf(
+          spacerElement?.previousElementSibling ?? null,
+        ),
+        spacerDomNext: describedRectOf(
+          spacerElement?.nextElementSibling ?? null,
+        ),
         dragged,
         draggedCenterDelta: dragged
           ? Math.hypot(dragged.centerX - mouse.x, dragged.centerY - mouse.y)
@@ -285,7 +556,11 @@ async function dragBy(
   text: string,
   index: number,
   delta: { x: number; y: number },
-  options: { steps?: number; assertCenter?: boolean; start?: { x: number; y: number } } = {},
+  options: {
+    steps?: number;
+    assertCenter?: boolean;
+    start?: { x: number; y: number };
+  } = {},
 ): Promise<DragSample[]> {
   const sourceRect = await itemRect(source);
   const activeGid = await source.getAttribute("data-engine-gid");
@@ -407,9 +682,15 @@ function expectNoSpacerBacktrack(samples: DragSample[], axis: "x" | "y") {
 function expectNoNestedParentFlicker(samples: DragSample[]) {
   const kinds = samples
     .map((sample) => sample.spacerParentKind)
-    .filter((kind): kind is string => kind === "nested-inner" || kind === "nested-outer");
+    .filter(
+      (kind): kind is string =>
+        kind === "nested-inner" || kind === "nested-outer",
+    );
   const firstInner = kinds.indexOf("nested-inner");
-  expect(firstInner, "drag should enter the nested sub-container").toBeGreaterThanOrEqual(0);
+  expect(
+    firstInner,
+    "drag should enter the nested sub-container",
+  ).toBeGreaterThanOrEqual(0);
 
   for (let i = firstInner + 1; i < kinds.length - 1; i++) {
     expect(
@@ -471,7 +752,9 @@ function compressedSpacerStates(samples: DragSample[]) {
     )
     .map((sample) => `${sample.spacerParentKind}[${sample.spacerIndex}]`);
 
-  return states.filter((state, index) => index === 0 || state !== states[index - 1]);
+  return states.filter(
+    (state, index) => index === 0 || state !== states[index - 1],
+  );
 }
 
 function expectSpacerAlignedAfterPrevious(
@@ -505,11 +788,12 @@ function expectSpacerNearDragged(
 ) {
   const candidates = samples.filter(
     (sample) =>
-      sample.spacer &&
-      sample.dragged &&
-      sample.spacerParentKind === parentKind,
+      sample.spacer && sample.dragged && sample.spacerParentKind === parentKind,
   );
-  expect(candidates, `expected spacer samples in ${parentKind}`).not.toHaveLength(0);
+  expect(
+    candidates,
+    `expected spacer samples in ${parentKind}`,
+  ).not.toHaveLength(0);
 
   const worst = candidates.reduce(
     (current, sample) => {
@@ -529,6 +813,82 @@ function expectSpacerNearDragged(
 test.describe("Snapsort drag-start snapshot layout", () => {
   test.beforeEach(async ({ page }) => {
     await installSnapsortTrace(page);
+  });
+
+  test("matches browser flex ghost positions for horizontal double-row fuzz cases", async ({
+    page,
+  }, testInfo) => {
+    const cases = horizontalDoubleRowLayoutCases();
+    const measuredCases = await measureBrowserLayoutCases(page, cases);
+    const failures: Array<{
+      name: string;
+      index: number;
+      expected: { x: number; y: number };
+      actual: { x: number; y: number };
+      delta: { x: number; y: number };
+    }> = [];
+
+    for (const measuredCase of measuredCases) {
+      const root = layoutNodeFromBrowserCase(measuredCase);
+      const dragged = root.children.find(
+        (item) => item.value === measuredCase.draggedId,
+      );
+      expect(
+        dragged,
+        `dragged item should exist for ${measuredCase.name}`,
+      ).toBeTruthy();
+
+      const origin = contentBoxOrigin(measuredCase.container);
+      for (const actual of measuredCase.actualGhosts) {
+        const simulated = flowLayoutPositions(
+          root,
+          dragged!,
+          origin.x,
+          origin.y,
+          {
+            container: root,
+            index: actual.index,
+            width: measuredCase.ghost.width,
+            height: measuredCase.ghost.height,
+          },
+        ).ghostPosition;
+        expect(
+          simulated,
+          `simulated ghost should exist for ${measuredCase.name}[${actual.index}]`,
+        ).toBeTruthy();
+
+        const delta = {
+          x: Math.abs(simulated!.x - actual.x),
+          y: Math.abs(simulated!.y - actual.y),
+        };
+        if (delta.x > 1.25 || delta.y > 1.25) {
+          failures.push({
+            name: measuredCase.name,
+            index: actual.index,
+            expected: { x: actual.x, y: actual.y },
+            actual: simulated!,
+            delta,
+          });
+        }
+      }
+    }
+
+    await writeJson(
+      testInfo.outputPath("horizontal-double-row-layout-fuzz.json"),
+      {
+        caseCount: measuredCases.length,
+        slotCount: measuredCases.reduce(
+          (count, measuredCase) => count + measuredCase.actualGhosts.length,
+          0,
+        ),
+        failures,
+      },
+    );
+
+    expect(
+      failures.slice(0, 8),
+      "layout engine ghost positions should match browser flex positions within 1.25px",
+    ).toHaveLength(0);
   });
 
   test("does not crash when drag movement arrives before snapshot capture", async ({
@@ -552,7 +912,9 @@ test.describe("Snapsort drag-start snapshot layout", () => {
 
     await writeJson(testInfo.outputPath("snapshot-readiness-trace.json"), {
       errors: consoleMessages.filter((message) =>
-        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(
+          message,
+        ),
       ),
       snapshotWaits: consoleMessages.filter((message) =>
         /waiting for drag snapshot/.test(message),
@@ -561,7 +923,9 @@ test.describe("Snapsort drag-start snapshot layout", () => {
 
     expect(
       consoleMessages.filter((message) =>
-        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(
+          message,
+        ),
       ),
     ).toHaveLength(0);
   });
@@ -586,8 +950,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
     const animated = await page.waitForFunction(() => {
       const items = [...document.querySelectorAll(".snapsort-item")].filter(
         (element) =>
-          element.id !== "spacer" &&
-          !/Item 1/.test(element.textContent ?? ""),
+          element.id !== "spacer" && !/Item 1/.test(element.textContent ?? ""),
       );
       return items.some((element) =>
         /^translate3d\(/.test((element as HTMLElement).style.transform),
@@ -599,14 +962,18 @@ test.describe("Snapsort drag-start snapshot layout", () => {
     await writeJson(testInfo.outputPath("reorder-animation-trace.json"), {
       animated: await animated.jsonValue(),
       errors: consoleMessages.filter((message) =>
-        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(
+          message,
+        ),
       ),
     });
 
     expect(await animated.jsonValue()).toBe(true);
     expect(
       consoleMessages.filter((message) =>
-        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(
+          message,
+        ),
       ),
     ).toHaveLength(0);
   });
@@ -730,16 +1097,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
     expect(
       states,
       `ghost should visit nested container boundary slots; observed ${states.join(" -> ")}`,
-    ).toEqual(
-      expect.arrayContaining([
-        "nested-inner[0]",
-        "nested-inner[3]",
-      ]),
-    );
-    expect(
-      ghostTargets,
-      `ghost should visit root boundary slots; observed ${ghostTargets.join(" -> ")}`,
-    ).toEqual(expect.arrayContaining(["407[2]", "407[4]"]));
+    ).toEqual(expect.arrayContaining(["nested-inner[0]", "nested-inner[3]"]));
   });
 
   test("creates a spacer when dragging a sub-container as an item", async ({

--- a/tests/e2e/snapsort-drag-snapshot.spec.ts
+++ b/tests/e2e/snapsort-drag-snapshot.spec.ts
@@ -11,7 +11,12 @@ type DragSample = {
   spacer: Rect | null;
   spacerParentGid: string | null;
   spacerParentKind: string | null;
+  spacerParentText: string | null;
   spacerIndex: number | null;
+  spacerPrevious: (Rect & { text: string }) | null;
+  spacerNext: (Rect & { text: string }) | null;
+  spacerDomPrevious: (Rect & { text: string }) | null;
+  spacerDomNext: (Rect & { text: string }) | null;
   dragged: (Rect & { centerX: number; centerY: number }) | null;
   draggedCenterDelta: number | null;
 };
@@ -188,6 +193,14 @@ async function collectSample(
           height: rect.height,
         };
       };
+      const describedRectOf = (element: Element | null) => {
+        const rect = rectOf(element);
+        if (!rect) return null;
+        return {
+          ...rect,
+          text: element?.textContent?.trim().replace(/\s+/g, " ") ?? "",
+        };
+      };
       const activeGid = win.__snapsortActiveGid ?? "";
       const draggedElement = document.querySelector(
         `[data-engine-gid="${activeGid}"]`,
@@ -202,11 +215,15 @@ async function collectSample(
               child.classList.contains("snapsort-container"),
           )
         : [];
+      const spacerSiblingIndex = spacerElement
+        ? spacerSiblings.indexOf(spacerElement)
+        : -1;
       const directSiblingTexts = spacerParent
         ? [...spacerParent.children]
             .filter((child) => child.id !== "spacer")
             .map((child) => child.textContent?.trim().replace(/\s+/g, " ") ?? "")
         : [];
+      const parentText = directSiblingTexts.join(" | ");
       const spacerParentKind =
         directSiblingTexts.length === 0
           ? null
@@ -214,6 +231,16 @@ async function collectSample(
             ? "nested-inner"
             : directSiblingTexts.some((text) => /Item 1\.5|Item 2|Item 3/.test(text))
               ? "nested-outer"
+              : directSiblingTexts.some((text) => /Header|Card Grid|Footer/.test(text))
+                ? "layers-root"
+                : directSiblingTexts.some((text) => /Hero Section/.test(text))
+                  ? "layers-hero"
+                  : directSiblingTexts.some((text) => /Loose Item/.test(text))
+                    ? "drag-root"
+                    : directSiblingTexts.some((text) => /Group 1 -/.test(text))
+                      ? "drag-group-1"
+                      : directSiblingTexts.some((text) => /Group 2 -/.test(text))
+                        ? "drag-group-2"
               : "other";
       const draggedRect = rectOf(draggedElement);
       const dragged = draggedRect
@@ -230,7 +257,18 @@ async function collectSample(
         spacer: rectOf(spacerElement),
         spacerParentGid: spacerParent?.getAttribute("data-engine-gid") ?? null,
         spacerParentKind,
-        spacerIndex: spacerElement ? spacerSiblings.indexOf(spacerElement) : null,
+        spacerParentText: parentText || null,
+        spacerIndex: spacerSiblingIndex === -1 ? null : spacerSiblingIndex,
+        spacerPrevious:
+          spacerSiblingIndex > 0
+            ? describedRectOf(spacerSiblings[spacerSiblingIndex - 1])
+            : null,
+        spacerNext:
+          spacerSiblingIndex >= 0 && spacerSiblingIndex < spacerSiblings.length - 1
+            ? describedRectOf(spacerSiblings[spacerSiblingIndex + 1])
+            : null,
+        spacerDomPrevious: describedRectOf(spacerElement?.previousElementSibling ?? null),
+        spacerDomNext: describedRectOf(spacerElement?.nextElementSibling ?? null),
         dragged,
         draggedCenterDelta: dragged
           ? Math.hypot(dragged.centerX - mouse.x, dragged.centerY - mouse.y)
@@ -436,9 +474,96 @@ function compressedSpacerStates(samples: DragSample[]) {
   return states.filter((state, index) => index === 0 || state !== states[index - 1]);
 }
 
+function expectSpacerAlignedAfterPrevious(
+  samples: DragSample[],
+  parentKind: string,
+  previousPattern: RegExp,
+) {
+  const sample = samples.find(
+    (entry) =>
+      entry.spacer &&
+      entry.spacerParentKind === parentKind &&
+      previousPattern.test(entry.spacerPrevious?.text ?? ""),
+  );
+  expect(
+    sample,
+    `expected spacer in ${parentKind} after ${previousPattern}`,
+  ).toBeTruthy();
+
+  const previous = sample!.spacerPrevious!;
+  const delta = Math.abs(sample!.spacer!.y - (previous.y + previous.height));
+  expect(
+    delta,
+    `spacer should align just below previous sibling; previous=${previous.text} delta=${delta}`,
+  ).toBeLessThan(24);
+}
+
+function expectSpacerNearDragged(
+  samples: DragSample[],
+  parentKind: string,
+  maxDistance: number,
+) {
+  const candidates = samples.filter(
+    (sample) =>
+      sample.spacer &&
+      sample.dragged &&
+      sample.spacerParentKind === parentKind,
+  );
+  expect(candidates, `expected spacer samples in ${parentKind}`).not.toHaveLength(0);
+
+  const worst = candidates.reduce(
+    (current, sample) => {
+      const spacerCenterY = sample.spacer!.y + sample.spacer!.height / 2;
+      const delta = Math.abs(spacerCenterY - sample.dragged!.centerY);
+      return delta > current.delta ? { sample, delta } : current;
+    },
+    { sample: candidates[0], delta: -Infinity },
+  );
+
+  expect(
+    worst.delta,
+    `spacer center should track dragged item center in ${parentKind}; worst step=${worst.sample.step}`,
+  ).toBeLessThan(maxDistance);
+}
+
 test.describe("Snapsort drag-start snapshot layout", () => {
   test.beforeEach(async ({ page }) => {
     await installSnapsortTrace(page);
+  });
+
+  test("does not crash when drag movement arrives before snapshot capture", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const verticalColumn = await demoBoxByHeading(page, "Vertical Column");
+    const item = await itemByTextIn(verticalColumn, "Item 1");
+    const itemCenter = center(await itemRect(item));
+
+    await page.mouse.move(itemCenter.x, itemCenter.y);
+    await page.mouse.down();
+    for (let step = 1; step <= 24; step++) {
+      await page.mouse.move(itemCenter.x, itemCenter.y + step * 4);
+    }
+    await page.mouse.up();
+    await page.waitForTimeout(100);
+
+    await writeJson(testInfo.outputPath("snapshot-readiness-trace.json"), {
+      errors: consoleMessages.filter((message) =>
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+      ),
+      snapshotWaits: consoleMessages.filter((message) =>
+        /waiting for drag snapshot/.test(message),
+      ),
+    });
+
+    expect(
+      consoleMessages.filter((message) =>
+        /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+      ),
+    ).toHaveLength(0);
   });
 
   test("does not flicker the spacer backward while dragging down a vertical column", async ({
@@ -612,6 +737,88 @@ test.describe("Snapsort drag-start snapshot layout", () => {
       samples.some((sample) => sample.spacerCount === 1 && sample.spacer),
       "dragging a sub-container should create and move a spacer",
     ).toBe(true);
+  });
+
+  test("keeps layer-panel ghost aligned below a labeled sub-container", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const layers = await demoBoxByHeading(page, "Layers Panel");
+    const header = await itemByTextIn(layers, "Header");
+    const hero = layers
+      .locator(".snapsort-container")
+      .filter({ hasText: "Hero Section" })
+      .nth(1);
+    await expect(hero).toBeVisible();
+    const headerRect = await itemRect(header);
+    const headerCenter = center(headerRect);
+    const heroRect = await itemRect(hero);
+    const targetCenterY =
+      heroRect.y + heroRect.height + headerRect.height / 2 + 12;
+    const samples = await dragBy(
+      page,
+      header,
+      "Header",
+      0,
+      {
+        x: 0,
+        y: targetCenterY - headerCenter.y,
+      },
+      { steps: 240 },
+    );
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("layers-panel-offset-trace.json"),
+    );
+    expectSpacerAlignedAfterPrevious(samples, "layers-root", /Hero Section/);
+    expectSpacerNearDragged(samples, "layers-root", 48);
+  });
+
+  test("keeps draggable sub-container ghost aligned after resized groups", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const cell = await demoBoxByHeading(page, "Draggable Sub-Containers");
+    const group1B = await itemByTextIn(cell, "Group 1 - B");
+    const group2 = cell
+      .locator(".snapsort-container")
+      .filter({ hasText: "Group 2 - A" })
+      .nth(1);
+    await expect(group2).toBeVisible();
+    const group1BRect = await itemRect(group1B);
+    const group1BCenter = center(group1BRect);
+    const group2Rect = await itemRect(group2);
+    const targetCenterY =
+      group2Rect.y + group2Rect.height + group1BRect.height / 2 + 12;
+    const samples = await dragBy(
+      page,
+      group1B,
+      "Group 1 - B",
+      0,
+      {
+        x: 0,
+        y: targetCenterY - group1BCenter.y,
+      },
+      { steps: 240 },
+    );
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("drag-subcontainer-offset-trace.json"),
+    );
+    expectSpacerAlignedAfterPrevious(samples, "drag-root", /Group 2 - A/);
+    expectSpacerNearDragged(samples, "drag-root", 48);
   });
 
   test("keeps one stable spacer while reordering a flat nested-items list", async ({

--- a/tests/e2e/snapsort-drag-snapshot.spec.ts
+++ b/tests/e2e/snapsort-drag-snapshot.spec.ts
@@ -1,0 +1,446 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+type Rect = { x: number; y: number; width: number; height: number };
+
+type DragSample = {
+  step: number;
+  mouse: { x: number; y: number };
+  spacerCount: number;
+  spacer: Rect | null;
+  dragged: (Rect & { centerX: number; centerY: number }) | null;
+  draggedCenterDelta: number | null;
+};
+
+type DomTraceEntry = {
+  type: string;
+  target: string;
+  parent?: string;
+  before?: string | null;
+  time: number;
+};
+
+async function installSnapsortTrace(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as unknown as {
+      __snapsortTrace: {
+        dom: DomTraceEntry[];
+        mutations: Array<{ type: string; target: string; attr: string | null; time: number }>;
+      };
+      __snapsortActiveText?: string;
+      __snapsortActiveIndex?: number;
+      __snapsortActiveGid?: string;
+    };
+
+    const trace = {
+      dom: [] as DomTraceEntry[],
+      mutations: [] as Array<{
+        type: string;
+        target: string;
+        attr: string | null;
+        time: number;
+      }>,
+    };
+    win.__snapsortTrace = trace;
+
+    const describe = (node: unknown) => {
+      if (!(node instanceof Element)) return String(node);
+      const text = node.textContent?.trim().replace(/\s+/g, " ").slice(0, 40);
+      const id = node.id ? `#${node.id}` : "";
+      const classes = [...node.classList].slice(0, 4).join(".");
+      return `${node.tagName.toLowerCase()}${id}${classes ? `.${classes}` : ""}${text ? ` "${text}"` : ""}`;
+    };
+
+    const shouldTrace = (node: unknown) =>
+      node instanceof Element &&
+      (node.id === "spacer" ||
+        node.classList.contains("snapsort-item-wrapper") ||
+        node.classList.contains("snapsort-container") ||
+        node.closest?.(".snapsort-container") != null);
+
+    const originalAppendChild = Node.prototype.appendChild;
+    Node.prototype.appendChild = function <T extends Node>(child: T): T {
+      if (shouldTrace(child) || shouldTrace(this)) {
+        trace.dom.push({
+          type: "appendChild",
+          target: describe(child),
+          parent: describe(this),
+          time: performance.now(),
+        });
+      }
+      return originalAppendChild.call(this, child) as T;
+    };
+
+    const originalInsertBefore = Node.prototype.insertBefore;
+    Node.prototype.insertBefore = function <T extends Node>(
+      child: T,
+      before: Node | null,
+    ): T {
+      if (shouldTrace(child) || shouldTrace(this)) {
+        trace.dom.push({
+          type: "insertBefore",
+          target: describe(child),
+          parent: describe(this),
+          before: before ? describe(before) : null,
+          time: performance.now(),
+        });
+      }
+      return originalInsertBefore.call(this, child, before) as T;
+    };
+
+    const originalRemove = Element.prototype.remove;
+    Element.prototype.remove = function () {
+      if (shouldTrace(this)) {
+        trace.dom.push({
+          type: "remove",
+          target: describe(this),
+          parent: describe(this.parentElement),
+          time: performance.now(),
+        });
+      }
+      return originalRemove.call(this);
+    };
+
+    new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (shouldTrace(mutation.target)) {
+          trace.mutations.push({
+            type: mutation.type,
+            target: describe(mutation.target),
+            attr: mutation.attributeName,
+            time: performance.now(),
+          });
+        }
+      }
+    }).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style", "data-engine-gid"],
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+function center(rect: Rect) {
+  return {
+    x: rect.x + rect.width / 2,
+    y: rect.y + rect.height / 2,
+  };
+}
+
+async function itemRect(item: Locator): Promise<Rect> {
+  const box = await item.boundingBox();
+  if (!box) throw new Error("Expected item to have a bounding box.");
+  return box;
+}
+
+async function itemByText(page: Page, text: string, index = 0) {
+  const locator = page
+    .locator(".snapsort-item-wrapper")
+    .filter({ hasText: text })
+    .nth(index);
+  await expect(locator).toBeVisible();
+  return locator;
+}
+
+async function demoBoxByHeading(page: Page, heading: string) {
+  const box = page
+    .locator(".demo-box")
+    .filter({ has: page.getByRole("heading", { name: heading }) });
+  await expect(box).toBeVisible();
+  return box;
+}
+
+async function itemByTextIn(parent: Locator, text: string, index = 0) {
+  const locator = parent
+    .locator(".snapsort-item-wrapper")
+    .filter({ hasText: text })
+    .nth(index);
+  await expect(locator).toBeVisible();
+  return locator;
+}
+
+async function collectSample(
+  page: Page,
+  step: number,
+  mouse: { x: number; y: number },
+): Promise<DragSample> {
+  return page.evaluate(
+    ({ step, mouse }) => {
+      const win = window as unknown as {
+        __snapsortActiveText?: string;
+        __snapsortActiveIndex?: number;
+        __snapsortActiveGid?: string;
+      };
+      const rectOf = (element: Element | null) => {
+        if (!element) return null;
+        const rect = element.getBoundingClientRect();
+        return {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        };
+      };
+      const activeGid = win.__snapsortActiveGid ?? "";
+      const draggedElement = document.querySelector(
+        `[data-engine-gid="${activeGid}"]`,
+      );
+      const draggedRect = rectOf(draggedElement);
+      const dragged = draggedRect
+        ? {
+            ...draggedRect,
+            centerX: draggedRect.x + draggedRect.width / 2,
+            centerY: draggedRect.y + draggedRect.height / 2,
+          }
+        : null;
+      return {
+        step,
+        mouse,
+        spacerCount: document.querySelectorAll("#spacer").length,
+        spacer: rectOf(document.querySelector("#spacer")),
+        dragged,
+        draggedCenterDelta: dragged
+          ? Math.hypot(dragged.centerX - mouse.x, dragged.centerY - mouse.y)
+          : null,
+      };
+    },
+    { step, mouse },
+  );
+}
+
+async function dragBy(
+  page: Page,
+  source: Locator,
+  text: string,
+  index: number,
+  delta: { x: number; y: number },
+): Promise<DragSample[]> {
+  const sourceRect = await itemRect(source);
+  const activeGid = await source.getAttribute("data-engine-gid");
+  const start = center(sourceRect);
+  await page.evaluate(
+    ({ text, index, activeGid }) => {
+      const win = window as unknown as {
+        __snapsortActiveText?: string;
+        __snapsortActiveIndex?: number;
+        __snapsortActiveGid?: string;
+      };
+      win.__snapsortActiveText = text;
+      win.__snapsortActiveIndex = index;
+      win.__snapsortActiveGid = activeGid ?? "";
+    },
+    { text, index, activeGid },
+  );
+
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+
+  const samples: DragSample[] = [];
+  for (let step = 1; step <= 18; step++) {
+    const mouse = {
+      x: start.x + (delta.x * step) / 18,
+      y: start.y + (delta.y * step) / 18,
+    };
+    await page.mouse.move(mouse.x, mouse.y);
+    await page.waitForTimeout(25);
+    samples.push(await collectSample(page, step, mouse));
+  }
+
+  await page.mouse.up();
+  await page.waitForTimeout(100);
+  return samples;
+}
+
+async function dragTo(
+  page: Page,
+  source: Locator,
+  text: string,
+  index: number,
+  target: Locator,
+): Promise<DragSample[]> {
+  const sourceCenter = center(await itemRect(source));
+  const targetCenter = center(await itemRect(target));
+  return dragBy(page, source, text, index, {
+    x: targetCenter.x - sourceCenter.x,
+    y: targetCenter.y - sourceCenter.y,
+  });
+}
+
+async function writeJson(path: string, value: unknown) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+async function expectStableDrag(
+  page: Page,
+  samples: DragSample[],
+  consoleMessages: string[],
+  outputPath: string,
+) {
+  const trace = await page.evaluate(() => {
+    const win = window as unknown as {
+      __snapsortTrace?: { dom: DomTraceEntry[]; mutations: unknown[] };
+    };
+    return win.__snapsortTrace;
+  });
+  await writeJson(outputPath, {
+    samples,
+    trace,
+    layoutLogs: consoleMessages.filter((message) =>
+      /\[updateDropTarget\]|\[updateGhostElement\]|\[insertItemAt\]|\[removeItemFrom\]|determineDropTarget|chosen|candidate/.test(
+        message,
+      ),
+    ),
+    errors: consoleMessages.filter((message) =>
+      /error|Missing drag snapshot|Unhandled|TypeError/i.test(message),
+    ),
+  });
+
+  expect(samples, "drag should produce frame samples").not.toHaveLength(0);
+  expect(
+    samples.filter((sample) => sample.spacerCount !== 1),
+    "the spacer should not disappear or duplicate while dragging",
+  ).toHaveLength(0);
+  expect(
+    Math.max(...samples.map((sample) => sample.draggedCenterDelta ?? 999)),
+    "dragged item center should remain close to the pointer",
+  ).toBeLessThan(12);
+  expect(
+    consoleMessages.filter((message) =>
+      /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
+    ),
+  ).toHaveLength(0);
+}
+
+test.describe("Snapsort drag-start snapshot layout", () => {
+  test.beforeEach(async ({ page }) => {
+    await installSnapsortTrace(page);
+  });
+
+  test("keeps one stable spacer while reordering a flat nested-items list", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=nested_items", { waitUntil: "networkidle" });
+    await page.screenshot({
+      path: testInfo.outputPath("nested-flat-before.png"),
+      fullPage: true,
+    });
+
+    const item = await itemByText(page, "Item B");
+    const samples = await dragBy(page, item, "Item B", 0, { x: 0, y: 110 });
+    await page.screenshot({
+      path: testInfo.outputPath("nested-flat-after.png"),
+      fullPage: true,
+    });
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("nested-flat-trace.json"),
+    );
+  });
+
+  test("keeps nested container drop prediction stable for padded sub-items", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=nested_items", { waitUntil: "networkidle" });
+    await page.screenshot({
+      path: testInfo.outputPath("nested-subitem-before.png"),
+      fullPage: true,
+    });
+
+    const item = await itemByText(page, "Sub A2");
+    const samples = await dragBy(page, item, "Sub A2", 0, { x: 0, y: 95 });
+    await page.screenshot({
+      path: testInfo.outputPath("nested-subitem-after.png"),
+      fullPage: true,
+    });
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("nested-subitem-trace.json"),
+    );
+  });
+
+  test("resolves multiple-drop-area container conflicts without spacer flicker", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drag_drop", { waitUntil: "networkidle" });
+    await page.screenshot({
+      path: testInfo.outputPath("multi-area-before.png"),
+      fullPage: true,
+    });
+
+    const item = await itemByText(page, "Item B");
+    const target = await itemByText(page, "Item Y");
+    const samples = await dragTo(page, item, "Item B", 0, target);
+    await page.screenshot({
+      path: testInfo.outputPath("multi-area-after.png"),
+      fullPage: true,
+    });
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("multi-area-trace.json"),
+    );
+  });
+
+  test("keeps wrapped row indices aligned beyond the first row", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drag_drop", { waitUntil: "networkidle" });
+    const doubleRow = await demoBoxByHeading(page, "Horizontal Double Row");
+    await page.screenshot({
+      path: testInfo.outputPath("wrapped-row-before.png"),
+      fullPage: true,
+    });
+
+    const item = await itemByTextIn(doubleRow, "Item 1");
+    const target = await itemByTextIn(doubleRow, "Item 9");
+    const samples = await dragTo(page, item, "Item 1", 0, target);
+    await page.screenshot({
+      path: testInfo.outputPath("wrapped-row-after.png"),
+      fullPage: true,
+    });
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("wrapped-row-trace.json"),
+    );
+
+    const order = await doubleRow
+      .locator(".snapsort-item-wrapper")
+      .evaluateAll((elements) =>
+        elements.map((element) => element.textContent?.trim()),
+      );
+    expect(order.slice(0, 10)).toEqual([
+      "Item 2",
+      "Item 3",
+      "Item 4",
+      "Item 5",
+      "Item 6",
+      "Item 7",
+      "Item 8",
+      "Item 9",
+      "Item 1",
+      "Item 10",
+    ]);
+  });
+});

--- a/tests/e2e/snapsort-drag-snapshot.spec.ts
+++ b/tests/e2e/snapsort-drag-snapshot.spec.ts
@@ -9,6 +9,9 @@ type DragSample = {
   mouse: { x: number; y: number };
   spacerCount: number;
   spacer: Rect | null;
+  spacerParentGid: string | null;
+  spacerParentKind: string | null;
+  spacerIndex: number | null;
   dragged: (Rect & { centerX: number; centerY: number }) | null;
   draggedCenterDelta: number | null;
 };
@@ -55,6 +58,7 @@ async function installSnapsortTrace(page: Page) {
     const shouldTrace = (node: unknown) =>
       node instanceof Element &&
       (node.id === "spacer" ||
+        node.classList.contains("snapsort-item") ||
         node.classList.contains("snapsort-item-wrapper") ||
         node.classList.contains("snapsort-container") ||
         node.closest?.(".snapsort-container") != null);
@@ -130,6 +134,7 @@ function center(rect: Rect) {
 }
 
 async function itemRect(item: Locator): Promise<Rect> {
+  await item.scrollIntoViewIfNeeded();
   const box = await item.boundingBox();
   if (!box) throw new Error("Expected item to have a bounding box.");
   return box;
@@ -137,7 +142,7 @@ async function itemRect(item: Locator): Promise<Rect> {
 
 async function itemByText(page: Page, text: string, index = 0) {
   const locator = page
-    .locator(".snapsort-item-wrapper")
+    .locator(".snapsort-item")
     .filter({ hasText: text })
     .nth(index);
   await expect(locator).toBeVisible();
@@ -146,7 +151,7 @@ async function itemByText(page: Page, text: string, index = 0) {
 
 async function demoBoxByHeading(page: Page, heading: string) {
   const box = page
-    .locator(".demo-box")
+    .locator(".demo-cell")
     .filter({ has: page.getByRole("heading", { name: heading }) });
   await expect(box).toBeVisible();
   return box;
@@ -154,7 +159,7 @@ async function demoBoxByHeading(page: Page, heading: string) {
 
 async function itemByTextIn(parent: Locator, text: string, index = 0) {
   const locator = parent
-    .locator(".snapsort-item-wrapper")
+    .locator(".snapsort-item")
     .filter({ hasText: text })
     .nth(index);
   await expect(locator).toBeVisible();
@@ -187,6 +192,29 @@ async function collectSample(
       const draggedElement = document.querySelector(
         `[data-engine-gid="${activeGid}"]`,
       );
+      const spacerElement = document.querySelector("#spacer");
+      const spacerParent = spacerElement?.parentElement ?? null;
+      const spacerSiblings = spacerParent
+        ? [...spacerParent.children].filter(
+            (child) =>
+              child.id === "spacer" ||
+              child.classList.contains("snapsort-item") ||
+              child.classList.contains("snapsort-container"),
+          )
+        : [];
+      const directSiblingTexts = spacerParent
+        ? [...spacerParent.children]
+            .filter((child) => child.id !== "spacer")
+            .map((child) => child.textContent?.trim().replace(/\s+/g, " ") ?? "")
+        : [];
+      const spacerParentKind =
+        directSiblingTexts.length === 0
+          ? null
+          : directSiblingTexts.every((text) => /^Sub A\d/.test(text))
+            ? "nested-inner"
+            : directSiblingTexts.some((text) => /Item 1\.5|Item 2|Item 3/.test(text))
+              ? "nested-outer"
+              : "other";
       const draggedRect = rectOf(draggedElement);
       const dragged = draggedRect
         ? {
@@ -199,7 +227,10 @@ async function collectSample(
         step,
         mouse,
         spacerCount: document.querySelectorAll("#spacer").length,
-        spacer: rectOf(document.querySelector("#spacer")),
+        spacer: rectOf(spacerElement),
+        spacerParentGid: spacerParent?.getAttribute("data-engine-gid") ?? null,
+        spacerParentKind,
+        spacerIndex: spacerElement ? spacerSiblings.indexOf(spacerElement) : null,
         dragged,
         draggedCenterDelta: dragged
           ? Math.hypot(dragged.centerX - mouse.x, dragged.centerY - mouse.y)
@@ -216,10 +247,12 @@ async function dragBy(
   text: string,
   index: number,
   delta: { x: number; y: number },
+  options: { steps?: number; assertCenter?: boolean; start?: { x: number; y: number } } = {},
 ): Promise<DragSample[]> {
   const sourceRect = await itemRect(source);
   const activeGid = await source.getAttribute("data-engine-gid");
-  const start = center(sourceRect);
+  const start = options.start ?? center(sourceRect);
+  const steps = options.steps ?? 160;
   await page.evaluate(
     ({ text, index, activeGid }) => {
       const win = window as unknown as {
@@ -238,13 +271,13 @@ async function dragBy(
   await page.mouse.down();
 
   const samples: DragSample[] = [];
-  for (let step = 1; step <= 18; step++) {
+  for (let step = 1; step <= steps; step++) {
     const mouse = {
-      x: start.x + (delta.x * step) / 18,
-      y: start.y + (delta.y * step) / 18,
+      x: start.x + (delta.x * step) / steps,
+      y: start.y + (delta.y * step) / steps,
     };
     await page.mouse.move(mouse.x, mouse.y);
-    await page.waitForTimeout(25);
+    await page.waitForTimeout(8);
     samples.push(await collectSample(page, step, mouse));
   }
 
@@ -278,6 +311,7 @@ async function expectStableDrag(
   samples: DragSample[],
   consoleMessages: string[],
   outputPath: string,
+  options: { assertCenter?: boolean } = {},
 ) {
   const trace = await page.evaluate(() => {
     const win = window as unknown as {
@@ -303,10 +337,12 @@ async function expectStableDrag(
     samples.filter((sample) => sample.spacerCount !== 1),
     "the spacer should not disappear or duplicate while dragging",
   ).toHaveLength(0);
-  expect(
-    Math.max(...samples.map((sample) => sample.draggedCenterDelta ?? 999)),
-    "dragged item center should remain close to the pointer",
-  ).toBeLessThan(12);
+  if (options.assertCenter !== false) {
+    expect(
+      Math.max(...samples.map((sample) => sample.draggedCenterDelta ?? 999)),
+      "dragged item center should remain close to the pointer",
+    ).toBeLessThan(12);
+  }
   expect(
     consoleMessages.filter((message) =>
       /Missing drag snapshot|Unhandled|TypeError|ReferenceError/i.test(message),
@@ -314,9 +350,268 @@ async function expectStableDrag(
   ).toHaveLength(0);
 }
 
+function expectNoSpacerBacktrack(samples: DragSample[], axis: "x" | "y") {
+  const positions = samples
+    .filter((sample) => sample.spacer)
+    .map((sample) => ({
+      step: sample.step,
+      value: sample.spacer![axis],
+    }));
+
+  for (let i = 1; i < positions.length; i++) {
+    expect(
+      positions[i].value + 8,
+      `spacer should not jump backward between steps ${positions[i - 1].step} and ${positions[i].step}`,
+    ).toBeGreaterThanOrEqual(positions[i - 1].value);
+  }
+}
+
+function expectNoNestedParentFlicker(samples: DragSample[]) {
+  const kinds = samples
+    .map((sample) => sample.spacerParentKind)
+    .filter((kind): kind is string => kind === "nested-inner" || kind === "nested-outer");
+  const firstInner = kinds.indexOf("nested-inner");
+  expect(firstInner, "drag should enter the nested sub-container").toBeGreaterThanOrEqual(0);
+
+  for (let i = firstInner + 1; i < kinds.length - 1; i++) {
+    expect(
+      !(kinds[i] === "nested-outer" && kinds[i + 1] === "nested-inner"),
+      "spacer should not briefly leave the nested container and re-enter on a smooth downward drag",
+    ).toBe(true);
+  }
+}
+
+function expectNoSpacerOscillation(samples: DragSample[]) {
+  const keys = samples
+    .filter((sample) => sample.spacer)
+    .map(
+      (sample) =>
+        `${Math.round(sample.spacer!.x)}:${Math.round(sample.spacer!.y)}:${sample.spacerIndex}`,
+    );
+
+  for (let i = 2; i < keys.length; i++) {
+    expect(
+      !(keys[i] === keys[i - 2] && keys[i] !== keys[i - 1]),
+      `spacer should not alternate between ${keys[i - 1]} and ${keys[i]} around sample ${i}`,
+    ).toBe(true);
+  }
+}
+
+function ghostInsertionTargets(consoleMessages: string[]) {
+  return consoleMessages.flatMap((message) => {
+    const match = message.match(
+      /\[updateGhostElement\] inserting ghost at container=([^\s]+) index=(\d+)/,
+    );
+    return match ? [`${match[1]}[${match[2]}]`] : [];
+  });
+}
+
+function expectGhostUpdatesStable(
+  consoleMessages: string[],
+  expectedMaxUpdates: number,
+) {
+  const targets = ghostInsertionTargets(consoleMessages);
+  expect(
+    targets.length,
+    `ghost should update only at stable slot transitions; saw ${targets.join(" -> ")}`,
+  ).toBeLessThanOrEqual(expectedMaxUpdates);
+
+  for (let i = 2; i < targets.length; i++) {
+    expect(
+      !(targets[i] === targets[i - 2] && targets[i] !== targets[i - 1]),
+      `ghost target should not oscillate: ${targets.join(" -> ")}`,
+    ).toBe(true);
+  }
+}
+
+function compressedSpacerStates(samples: DragSample[]) {
+  const states = samples
+    .filter(
+      (sample) =>
+        sample.spacerParentKind === "nested-inner" ||
+        sample.spacerParentKind === "nested-outer",
+    )
+    .map((sample) => `${sample.spacerParentKind}[${sample.spacerIndex}]`);
+
+  return states.filter((state, index) => index === 0 || state !== states[index - 1]);
+}
+
 test.describe("Snapsort drag-start snapshot layout", () => {
   test.beforeEach(async ({ page }) => {
     await installSnapsortTrace(page);
+  });
+
+  test("does not flicker the spacer backward while dragging down a vertical column", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const verticalColumn = await demoBoxByHeading(page, "Vertical Column");
+    const item = await itemByTextIn(verticalColumn, "Item 1");
+    const target = await itemByTextIn(verticalColumn, "Item 4");
+    const itemCenter = center(await itemRect(item));
+    const targetCenter = center(await itemRect(target));
+    const samples = await dragBy(page, item, "Item 1", 0, {
+      x: 0,
+      y: targetCenter.y - itemCenter.y + 48,
+    });
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("vertical-column-flicker-trace.json"),
+    );
+    expectNoSpacerBacktrack(samples, "y");
+    expectNoSpacerOscillation(samples);
+    expectGhostUpdatesStable(consoleMessages, 5);
+  });
+
+  test("does not flicker the spacer upward while dragging into a wrapped horizontal row", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const horizontalRow = await demoBoxByHeading(page, "Horizontal Row");
+    const item = await itemByTextIn(horizontalRow, "Item 1");
+    const target = await itemByTextIn(horizontalRow, "Item 4");
+    const itemCenter = center(await itemRect(item));
+    const targetCenter = center(await itemRect(target));
+    const samples = await dragBy(page, item, "Item 1", 0, {
+      x: 0,
+      y: targetCenter.y - itemCenter.y,
+    });
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("horizontal-row-wrap-flicker-trace.json"),
+    );
+    expectNoSpacerBacktrack(samples, "y");
+    expectNoSpacerOscillation(samples);
+    expectGhostUpdatesStable(consoleMessages, 3);
+  });
+
+  test("does not flicker out of a nested column after entering it", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const nested = await demoBoxByHeading(page, "Nested Container");
+    const item = await itemByTextIn(nested, "Item 1");
+    const target = await itemByTextIn(nested, "Sub A3");
+    const samples = await dragTo(page, item, "Item 1", 0, target);
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("nested-container-flicker-trace.json"),
+    );
+    expectNoNestedParentFlicker(samples);
+    expectGhostUpdatesStable(consoleMessages, 6);
+  });
+
+  test("can reach nested column boundary slots while dragging root item downward", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const nested = await demoBoxByHeading(page, "Nested Container");
+    const item = await itemByTextIn(nested, "Item 1");
+    const item3 = await itemByTextIn(nested, "Item 3");
+    const itemCenter = center(await itemRect(item));
+    const item3Center = center(await itemRect(item3));
+    const samples = await dragBy(
+      page,
+      item,
+      "Item 1",
+      0,
+      {
+        x: 0,
+        y: item3Center.y - itemCenter.y + 96,
+      },
+      { steps: 240 },
+    );
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("nested-boundary-slots-trace.json"),
+    );
+
+    const states = compressedSpacerStates(samples);
+    const ghostTargets = ghostInsertionTargets(consoleMessages);
+    await writeJson(testInfo.outputPath("nested-boundary-slots-states.json"), {
+      states,
+      ghostTargets,
+    });
+
+    expect(
+      states,
+      `ghost should visit nested container boundary slots; observed ${states.join(" -> ")}`,
+    ).toEqual(
+      expect.arrayContaining([
+        "nested-inner[0]",
+        "nested-inner[3]",
+      ]),
+    );
+    expect(
+      ghostTargets,
+      `ghost should visit root boundary slots; observed ${ghostTargets.join(" -> ")}`,
+    ).toEqual(expect.arrayContaining(["407[2]", "407[4]"]));
+  });
+
+  test("creates a spacer when dragging a sub-container as an item", async ({
+    page,
+  }, testInfo) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => consoleMessages.push(message.text()));
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
+
+    const cell = await demoBoxByHeading(page, "Draggable Sub-Containers");
+    const source = cell
+      .locator(".snapsort-container .snapsort-container")
+      .filter({ hasText: "Group 1 - A" })
+      .first();
+    await expect(source).toBeVisible();
+    const target = await itemByTextIn(cell, "Loose Item");
+    const sourceRect = await itemRect(source);
+    const targetCenter = center(await itemRect(target));
+    const start = { x: sourceRect.x + 8, y: sourceRect.y + 8 };
+    const samples = await dragBy(
+      page,
+      source,
+      "Group 1",
+      0,
+      {
+        x: targetCenter.x - start.x,
+        y: targetCenter.y - start.y,
+      },
+      { start, assertCenter: false },
+    );
+
+    await expectStableDrag(
+      page,
+      samples,
+      consoleMessages,
+      testInfo.outputPath("drag-container-trace.json"),
+      { assertCenter: false },
+    );
+    expect(
+      samples.some((sample) => sample.spacerCount === 1 && sample.spacer),
+      "dragging a sub-container should create and move a spacer",
+    ).toBe(true);
   });
 
   test("keeps one stable spacer while reordering a flat nested-items list", async ({
@@ -324,7 +619,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
   }, testInfo) => {
     const consoleMessages: string[] = [];
     page.on("console", (message) => consoleMessages.push(message.text()));
-    await page.goto("/?demo=nested_items", { waitUntil: "networkidle" });
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
     await page.screenshot({
       path: testInfo.outputPath("nested-flat-before.png"),
       fullPage: true,
@@ -350,7 +645,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
   }, testInfo) => {
     const consoleMessages: string[] = [];
     page.on("console", (message) => consoleMessages.push(message.text()));
-    await page.goto("/?demo=nested_items", { waitUntil: "networkidle" });
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
     await page.screenshot({
       path: testInfo.outputPath("nested-subitem-before.png"),
       fullPage: true,
@@ -376,7 +671,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
   }, testInfo) => {
     const consoleMessages: string[] = [];
     page.on("console", (message) => consoleMessages.push(message.text()));
-    await page.goto("/?demo=drag_drop", { waitUntil: "networkidle" });
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
     await page.screenshot({
       path: testInfo.outputPath("multi-area-before.png"),
       fullPage: true,
@@ -403,7 +698,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
   }, testInfo) => {
     const consoleMessages: string[] = [];
     page.on("console", (message) => consoleMessages.push(message.text()));
-    await page.goto("/?demo=drag_drop", { waitUntil: "networkidle" });
+    await page.goto("/?demo=drop_snap_nested", { waitUntil: "networkidle" });
     const doubleRow = await demoBoxByHeading(page, "Horizontal Double Row");
     await page.screenshot({
       path: testInfo.outputPath("wrapped-row-before.png"),
@@ -426,7 +721,7 @@ test.describe("Snapsort drag-start snapshot layout", () => {
     );
 
     const order = await doubleRow
-      .locator(".snapsort-item-wrapper")
+      .locator(".snapsort-item")
       .evaluateAll((elements) =>
         elements.map((element) => element.textContent?.trim()),
       );

--- a/tests/e2e/snapsort.playwright.config.ts
+++ b/tests/e2e/snapsort.playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const port = Number(process.env.SNAPSORT_TEST_PORT ?? 3027);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "snapsort-drag-snapshot.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    channel: "chrome",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    viewport: { width: 1400, height: 950 },
+  },
+  webServer: {
+    cwd: repoRoot,
+    command: `npx vite serve demo/svelte --config demo/svelte/vite.config.mjs --host 127.0.0.1 --port ${port} --strictPort --force`,
+    url: `http://127.0.0.1:${port}`,
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary

Refactors SnapSort drop prediction so the flex layout simulation lives in a dedicated layout engine module that operates on frozen layout snapshot nodes instead of live SnapSort objects.

Adds browser-measured Playwright fuzz coverage for the horizontal double-row case across narrow width increments, varied padding, border widths, item sizes, and gaps. The test compares simulated ghost positions against actual Chromium flex layout positions for every insertion slot.

Also gates the high-volume drag debug logging so normal drag interactions no longer emit massive console output.

## Impact

- Drop target scoring now asks the layout engine where a specific ghost insertion would land, then chooses the closest candidate in `drop_target.ts`.
- The layout engine is independently testable against browser flex behavior.
- Dragging SnapSort demos should be much less laggy because per-frame debug logs are disabled.

## Validation

- `npm run test:snapsort -- --grep "matches browser flex ghost positions|keeps wrapped row indices|can reach nested column boundary"`
- `npm run build`

Note: `npx tsc --noEmit -p assets/snapsort/core/tsconfig.json` still reports pre-existing `item.ts` issues unrelated to this refactor.